### PR TITLE
Add toggle for hiding files with FAT32 hidden attribute

### DIFF
--- a/arm9/source/fat/FastFileRef.h
+++ b/arm9/source/fat/FastFileRef.h
@@ -8,6 +8,7 @@ class FastFileRef
     u32 _dirSectorOffset;
     u32 _startCluster;
     FSIZE_t _fileSize;
+    bool _hidden;
 
 public:
     FastFileRef() { }
@@ -15,11 +16,12 @@ public:
     explicit FastFileRef(const DIR* directory, const FILINFO* fileInfo)
         : _fatFs(directory->obj.fs), _dirSector(fileInfo->fdirsect)
         , _dirSectorOffset(fileInfo->fdiroffs), _startCluster(fileInfo->fclust)
-        , _fileSize(fileInfo->fsize) { }
+        , _fileSize(fileInfo->fsize), _hidden((fileInfo->fattrib & AM_HID) != 0) { }
 
     FATFS* GetFatFs() const { return _fatFs; }
     u32 GetDirSector() const { return _dirSector; }
     u32 GetDirSectorOffset() const { return _dirSectorOffset; }
     u32 GetStartCluster() const { return _startCluster; }
     FSIZE_t GetFileSize() const { return _fileSize; }
+    bool GetHidden() const { return _hidden; }
 };

--- a/arm9/source/romBrowser/SdFolder.cpp
+++ b/arm9/source/romBrowser/SdFolder.cpp
@@ -21,6 +21,12 @@ std::unique_ptr<const FileInfo*[]> SdFolder::FilterAndSort(
     for (int i = 0; i < _fileCount; i++)
     {
         const FileInfo* file = _files[i];
+        auto hidden = file->GetFastFileRef().GetHidden();
+        if (hidden && !filterSortParams.showHiddenFiles)
+        {
+            continue;
+        }
+
         auto classification = file->GetFileType()->GetClassification();
         if (classification != FileTypeClassification::Unknown)
         {

--- a/arm9/source/romBrowser/SdFolderFilterSortParams.h
+++ b/arm9/source/romBrowser/SdFolderFilterSortParams.h
@@ -7,9 +7,13 @@ class SdFolderFilterSortParams
 public:
     SdFolderSortType sortType = SdFolderSortType::Name;
     SdFolderSortDirection sortDirection = SdFolderSortDirection::Ascending;
+    bool showHiddenFiles = false;
 
     SdFolderFilterSortParams() { }
 
     SdFolderFilterSortParams(SdFolderSortType sortType, SdFolderSortDirection sortDirection)
         : sortType(sortType), sortDirection(sortDirection) { }
+
+    SdFolderFilterSortParams(SdFolderSortType sortType, SdFolderSortDirection sortDirection, bool showHiddenFiles)
+        : sortType(sortType), sortDirection(sortDirection), showHiddenFiles(showHiddenFiles) { }
 };

--- a/arm9/source/romBrowser/viewModels/RomBrowserViewModel.cpp
+++ b/arm9/source/romBrowser/viewModels/RomBrowserViewModel.cpp
@@ -6,28 +6,30 @@ RomBrowserViewModel::RomBrowserViewModel(IRomBrowserController* romBrowserContro
     : _romBrowserController(romBrowserController)
 {
     SdFolderFilterSortParams filterSortParams;
+    auto showHiddenFiles = romBrowserController->GetRomBrowserDisplaySettings().showHiddenFiles;
     switch (romBrowserController->GetRomBrowserDisplaySettings().sortMode)
     {
         case RomBrowserSortMode::NameAscending:
         default:
         {
             filterSortParams = SdFolderFilterSortParams(
-                SdFolderSortType::Name, SdFolderSortDirection::Ascending);
+                SdFolderSortType::Name, SdFolderSortDirection::Ascending, showHiddenFiles);
             break;
         }
         case RomBrowserSortMode::NameDescending:
         {
             filterSortParams = SdFolderFilterSortParams(
-                SdFolderSortType::Name, SdFolderSortDirection::Descending);
+                SdFolderSortType::Name, SdFolderSortDirection::Descending, showHiddenFiles);
             break;
         }
         case RomBrowserSortMode::LastModified:
         {
             filterSortParams = SdFolderFilterSortParams(
-                SdFolderSortType::LastModified, SdFolderSortDirection::Descending);
+                SdFolderSortType::LastModified, SdFolderSortDirection::Descending, showHiddenFiles);
             break;
         }
     }
+
     u64 startTick = gTickCounter.GetValue();
     const auto& sdFolder = romBrowserController->GetSdFolder();
     int filteredCount;

--- a/arm9/source/services/settings/JsonAppSettingsSerializer.thumb.cpp
+++ b/arm9/source/services/settings/JsonAppSettingsSerializer.thumb.cpp
@@ -10,6 +10,7 @@
 #define JSON_RESERVED_SIZE  2048
 
 #define KEY_LANGUAGE                 "language"
+#define KEY_SHOW_HIDDEN_FILES        "showHiddenFiles"
 #define KEY_ROM_BROWSER_LAYOUT       "romBrowserLayout"
 #define KEY_ROM_BROWSER_SORT_MODE    "romBrowserSortMode"
 #define KEY_THEME                    "theme"
@@ -125,6 +126,7 @@ static std::unique_ptr<u8[]> writeJson(const AppSettings* appSettings, u32& leng
 {
     DynamicJsonDocument json(JSON_RESERVED_SIZE);
     json[KEY_LANGUAGE] = appSettings->language.GetString();
+    json[KEY_SHOW_HIDDEN_FILES] = appSettings->romBrowserDisplaySettings.showHiddenFiles;
     json[KEY_ROM_BROWSER_LAYOUT] = serializeRomBrowserLayout(appSettings->romBrowserDisplaySettings.layout);
     json[KEY_ROM_BROWSER_SORT_MODE] = serializeRomBrowserSortMode(appSettings->romBrowserDisplaySettings.sortMode);
     json[KEY_THEME] = appSettings->theme.GetString();
@@ -167,6 +169,7 @@ static void readJson(AppSettings* appSettings, const JsonDocument& json)
     appSettings->language = json[KEY_LANGUAGE] | appSettings->language.GetString();
     appSettings->theme = json[KEY_THEME] | appSettings->theme.GetString();
     appSettings->lastUsedFilePath = json[KEY_LAST_USED_FILE_PATH] | appSettings->lastUsedFilePath.GetString();
+    appSettings->romBrowserDisplaySettings.showHiddenFiles = json[KEY_SHOW_HIDDEN_FILES].isNull() ? appSettings->romBrowserDisplaySettings.showHiddenFiles : json[KEY_SHOW_HIDDEN_FILES];
 
     RomBrowserLayout romBrowserLayout;
     if (tryParseRomBrowserLayout(json[KEY_ROM_BROWSER_LAYOUT].as<const char*>(),

--- a/arm9/source/services/settings/RomBrowserDisplaySettings.h
+++ b/arm9/source/services/settings/RomBrowserDisplaySettings.h
@@ -7,4 +7,5 @@ class RomBrowserDisplaySettings
 public:
     RomBrowserLayout layout = RomBrowserLayout::HorizontalIconGrid;
     RomBrowserSortMode sortMode = RomBrowserSortMode::NameAscending;
+    bool showHiddenFiles = false;
 };


### PR DESCRIPTION
While searching for a way to not show hidden files in the ROM browser, I found #13 and #23 (specifically https://github.com/LNH-team/pico-launcher/issues/13#issuecomment-3850222771), and thought PRing a solution using the FAT32 "hidden" attribute, toggleable from the pico-launcher `settings.json`, may be helpful. I haven't attempted to add this toggle to the settings popover UI at all however.

Not sure that the way I've exposed the hidden attribute in `FastFileRef` is the *best* way to do it - happy to rework with suggestions.

Tested working on DSpico (on a DSi XL).