### PR TITLE
Support defaultFolder which overrides the last navigated to path

### DIFF
--- a/arm9/source/romBrowser/RomBrowserController.cpp
+++ b/arm9/source/romBrowser/RomBrowserController.cpp
@@ -77,8 +77,13 @@ void RomBrowserController::Update()
         case RomBrowserState::Start:
         {
             LOG_DEBUG("RomBrowserState::Start\n");
+            const auto& defaultFolder = _appSettingsService->GetAppSettings().defaultFolder;
             const auto& lastUsed = _appSettingsService->GetAppSettings().lastUsedFilePath;
-            if (strlen(lastUsed.GetString()) != 0)
+            if (strlen(defaultFolder.GetString()) != 0)
+            {
+                NavigateToPath(defaultFolder.GetString());
+            }
+            else if (strlen(lastUsed.GetString()) != 0)
             {
                 NavigateToPath(lastUsed.GetString());
             }

--- a/arm9/source/services/settings/AppSettings.h
+++ b/arm9/source/services/settings/AppSettings.h
@@ -10,6 +10,7 @@ public:
     String<char, 16> language = "english";
     String<char, 64> theme = "material";
     String<char, 256> lastUsedFilePath = "";
+    String<char, 256> defaultFolder = "";
     RomBrowserDisplaySettings romBrowserDisplaySettings;
 
     std::unique_ptr<FileAssociation[]> fileAssociations;

--- a/arm9/source/services/settings/JsonAppSettingsSerializer.thumb.cpp
+++ b/arm9/source/services/settings/JsonAppSettingsSerializer.thumb.cpp
@@ -14,6 +14,7 @@
 #define KEY_ROM_BROWSER_SORT_MODE    "romBrowserSortMode"
 #define KEY_THEME                    "theme"
 #define KEY_LAST_USED_FILE_PATH      "lastUsedFilePath"
+#define KEY_DEFAULT_FOLDER           "defaultFolder"
 #define KEY_FILE_ASSOCIATIONS        "fileAssociations"
 #define KEY_FILE_ASSOCIATIONS_APPLICATION_PATH  "appPath"
 
@@ -129,6 +130,7 @@ static std::unique_ptr<u8[]> writeJson(const AppSettings* appSettings, u32& leng
     json[KEY_ROM_BROWSER_SORT_MODE] = serializeRomBrowserSortMode(appSettings->romBrowserDisplaySettings.sortMode);
     json[KEY_THEME] = appSettings->theme.GetString();
     json[KEY_LAST_USED_FILE_PATH] = appSettings->lastUsedFilePath.GetString();
+    json[KEY_DEFAULT_FOLDER] = appSettings->defaultFolder.GetString();
     serializeFileAssociations(json, appSettings);
 
     u32 outputSize = measureJsonPretty(json);
@@ -167,6 +169,8 @@ static void readJson(AppSettings* appSettings, const JsonDocument& json)
     appSettings->language = json[KEY_LANGUAGE] | appSettings->language.GetString();
     appSettings->theme = json[KEY_THEME] | appSettings->theme.GetString();
     appSettings->lastUsedFilePath = json[KEY_LAST_USED_FILE_PATH] | appSettings->lastUsedFilePath.GetString();
+    appSettings->defaultFolder = json[KEY_DEFAULT_FOLDER] | appSettings->defaultFolder.GetString();
+    appSettings->romBrowserDisplaySettings.showHiddenFiles = json[KEY_SHOW_HIDDEN_FILES].isNull() ? appSettings->romBrowserDisplaySettings.showHiddenFiles : json[KEY_SHOW_HIDDEN_FILES];
 
     RomBrowserLayout romBrowserLayout;
     if (tryParseRomBrowserLayout(json[KEY_ROM_BROWSER_LAYOUT].as<const char*>(),


### PR DESCRIPTION
Allow specifying a "defaultFolder" in settings.json which the app will always open to instead of just the last used folder