### PR TITLE
Implemented the option to hide folders

### DIFF
--- a/arm9/source/romBrowser/RomBrowserController.cpp
+++ b/arm9/source/romBrowser/RomBrowserController.cpp
@@ -169,7 +169,14 @@ void RomBrowserController::HandleNavigateTrigger()
             }
         }
         f_chdir(_navigatePath);
-        SdFolderFactory sdFolderFactory { &_fileTypeProvider };
+
+        const auto& appSettings = _appSettingsService->GetAppSettings();
+        const char* hidePatternPtrs[AppSettings::MaxHidePatterns];
+        for (u32 i = 0; i < appSettings.numberOfHidePatterns; i++)
+            hidePatternPtrs[i] = appSettings.hidePatterns[i].GetString();
+
+        SdFolderFactory sdFolderFactory { &_fileTypeProvider,
+            hidePatternPtrs, appSettings.numberOfHidePatterns };
         _newSdFolder = sdFolderFactory.CreateFromPath(".");
         u64 endTick = gTickCounter.GetValue();
         LOG_DEBUG("Loading files in folder took: %d us\n", (u32)TickCounter::TicksToMicroSeconds(endTick - startTick));

--- a/arm9/source/romBrowser/SdFolderFactory.cpp
+++ b/arm9/source/romBrowser/SdFolderFactory.cpp
@@ -5,6 +5,38 @@
 #include "FileType/Folder/FolderFileType.h"
 #include "SdFolderFactory.h"
 
+static bool GlobMatch(const char* pat, const char* str)
+{
+    while (*pat && *str)
+    {
+        if (*pat == '*')
+        {
+            while (*pat == '*') pat++; // Skip consecutive wildcards
+            if (!*pat) return true; // Trailing * matches everything
+            while (*str)
+            {
+                if (GlobMatch(pat, str++)) return true;
+            }
+            return false;
+        }
+        if (*pat != '?' && tolower((unsigned char)*pat) != tolower((unsigned char)*str))
+            return false;
+        pat++; str++;
+    }
+    while (*pat == '*') pat++;
+    return !*pat && !*str;
+}
+
+static bool ShouldHide(const char* name, const char* const* patterns, int count)
+{
+    for (int i = 0; i < count; i++)
+    {
+        if (patterns[i] && GlobMatch(patterns[i], name)) return true;
+    }
+
+    return false;
+}
+
 std::unique_ptr<SdFolder> SdFolderFactory::CreateFromPath(const char* path) const
 {
     Directory directory;
@@ -22,6 +54,9 @@ std::unique_ptr<SdFolder> SdFolderFactory::CreateFromPath(const char* path) cons
 
         if (sdFileInfo->fname[0] == 0)
             break;
+
+        if (ShouldHide(sdFileInfo->fname, _hidePatterns, _hidePatternCount))
+            continue;
 
         if (count >= bufferSize)
         {

--- a/arm9/source/romBrowser/SdFolderFactory.h
+++ b/arm9/source/romBrowser/SdFolderFactory.h
@@ -6,11 +6,16 @@
 class SdFolderFactory
 {
 public:
-    SdFolderFactory(const IFileTypeProvider* fileTypeProvider)
-        : _fileTypeProvider(fileTypeProvider) { }
+    SdFolderFactory(const IFileTypeProvider* fileTypeProvider,
+        const char* const* hidePatterns = nullptr, u32 hidePatternCount = 0)
+        : _fileTypeProvider(fileTypeProvider)
+        , _hidePatterns(hidePatterns)
+        , _hidePatternCount(hidePatternCount) { }
 
     std::unique_ptr<SdFolder> CreateFromPath(const char* path) const;
 
 private:
     const IFileTypeProvider* _fileTypeProvider;
+    const char* const* _hidePatterns;
+    u32 _hidePatternCount;
 };

--- a/arm9/source/services/settings/AppSettings.h
+++ b/arm9/source/services/settings/AppSettings.h
@@ -14,4 +14,8 @@ public:
 
     std::unique_ptr<FileAssociation[]> fileAssociations;
     u32 numberOfFileAssociations = 0;
+
+    static constexpr u32 MaxHidePatterns = 8;
+    String<char, 128> hidePatterns[MaxHidePatterns];
+    u32 numberOfHidePatterns = 0;
 };

--- a/arm9/source/services/settings/JsonAppSettingsSerializer.thumb.cpp
+++ b/arm9/source/services/settings/JsonAppSettingsSerializer.thumb.cpp
@@ -7,7 +7,7 @@
 
 #pragma GCC optimize("Os")
 
-#define JSON_RESERVED_SIZE  2048
+#define JSON_RESERVED_SIZE  4096
 
 #define KEY_LANGUAGE                 "language"
 #define KEY_ROM_BROWSER_LAYOUT       "romBrowserLayout"
@@ -16,6 +16,7 @@
 #define KEY_LAST_USED_FILE_PATH      "lastUsedFilePath"
 #define KEY_FILE_ASSOCIATIONS        "fileAssociations"
 #define KEY_FILE_ASSOCIATIONS_APPLICATION_PATH  "appPath"
+#define KEY_HIDE_PATTERNS            "hidePatterns"
 
 static const char* serializeRomBrowserLayout(RomBrowserLayout romBrowserLayout)
 {
@@ -121,6 +122,32 @@ static void serializeFileAssociations(DynamicJsonDocument& json, const AppSettin
     }
 }
 
+static bool tryParseHidePatterns(const JsonArrayConst& json, AppSettings* appSettings)
+{
+    if (json.isNull())
+    {
+        return false;
+    }
+
+    appSettings->numberOfHidePatterns = 0;
+    for (auto item : json)
+    {
+        if (appSettings->numberOfHidePatterns >= AppSettings::MaxHidePatterns)
+            break;
+        const char* pat = item.as<const char*>();
+        if (pat)
+            appSettings->hidePatterns[appSettings->numberOfHidePatterns++] = pat;
+    }
+    return true;
+}
+
+static void serializeHidePatterns(DynamicJsonDocument& json, const AppSettings* appSettings)
+{
+    auto jsonObject = json[KEY_HIDE_PATTERNS].to<JsonArray>();
+    for (u32 i = 0; i < appSettings->numberOfHidePatterns; i++)
+        jsonObject.add(appSettings->hidePatterns[i].GetString());
+}
+
 static std::unique_ptr<u8[]> writeJson(const AppSettings* appSettings, u32& length)
 {
     DynamicJsonDocument json(JSON_RESERVED_SIZE);
@@ -130,6 +157,7 @@ static std::unique_ptr<u8[]> writeJson(const AppSettings* appSettings, u32& leng
     json[KEY_THEME] = appSettings->theme.GetString();
     json[KEY_LAST_USED_FILE_PATH] = appSettings->lastUsedFilePath.GetString();
     serializeFileAssociations(json, appSettings);
+    serializeHidePatterns(json, appSettings);
 
     u32 outputSize = measureJsonPretty(json);
     std::unique_ptr<u8[]> fileData(new(cache_align) u8[outputSize]);
@@ -182,6 +210,7 @@ static void readJson(AppSettings* appSettings, const JsonDocument& json)
     }
 
     tryParseFileAssociations(json[KEY_FILE_ASSOCIATIONS], appSettings);
+    tryParseHidePatterns(json[KEY_HIDE_PATTERNS], appSettings);
 }
 
 bool JsonAppSettingsSerializer::Deserialize(AppSettings* appSettings, const char* filePath) const

--- a/docs/HidePatterns.md
+++ b/docs/HidePatterns.md
@@ -1,0 +1,26 @@
+# Hide Patterns
+An optional list of file and folder names to hide from the browser.
+Each entry is a literal name or a glob pattern using `*` (matches any characters) and `?` (matches exactly one character). Matching is case-insensitive. Up to 8 patterns at a time are supported.
+
+## How to setup hide patterns
+1. Open `/_pico/settings.json`.
+2. If not present yet, add a `hidePatterns` key.
+3. For a folder or file that you wish to hide from the browser add an entry inside the `hidePatterns` key. For example:
+    ```json
+    "hidePatterns": [
+        "_pico",
+        "_picoboot.nds"
+    ]
+    ```
+    (if you are using DSpico)
+
+Or to simply hide everything that starts with an underscore:
+
+```json
+"hidePatterns": [
+    "_*"
+]
+```
+
+> **Note**  
+> Using a `*` without any characters next to it will hide **everything** in the browser

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -48,3 +48,4 @@ Settings are stored on your SD card in `/_pico/settings.json`. They can be edite
 - `theme`: Specifies the folder name of the theme to use. If the theme cannot be found, a default fallback theme will be used.
 - `lastUsedFilePath` - Specifies the path of the most recently launched homebrew or game, such that it can be selected the next time Pico Launcher is started. It is automatically updated by Pico Launcher.
 - `fileAssociations` - See [FileAssociations.md](/docs/FileAssociations.md) for information about how to use this setting.
+- `hidePatterns` - See [HidePatterns.md](/docs/HidePatterns.md) for information about how to use this setting.


### PR DESCRIPTION
System files and folders can now be selected to not show up in the browser. Reducing clutter in the menu

Extended SdFolderFactory to have a `ShouldHide` check based on entries in the settings.json. A `hidePatterns` entry has been added in this format:

  ```json
  "hidePatterns": [
      "_pico",
      "_picoboot.nds"
  ]
  ```
This also implements wildcard matching:
- _*
- _pico*
- .Trash*

The number of patterns that can be used at one time has a limit of 8 (just to reduce json memory usage and limit number of loops to check a match). Any more than that will be ignored.

Simple documentation has been added.

I found in my testing that filling up the settings.json with many FileAssociation and HidePattern entries would cause the settings.json to never be loaded and for `Serialize` to override the entire file with default values.

Even enough FileAssociations on their own should be enough to hit this limit and reset settings. To account for this JSON_RESERVED_SIZE has been changed from 2048 to 4096.

Tested and working on a DSi and DS lite.
Hand tested many patterns and garbage data. Could not trigger a crash or reset; besides the `readJson` issue mentioned earlier. Which as been far less easy to run into after the change to the reserved size.