### PR TITLE
Filter out files and folders starting with '_'

### DIFF
--- a/arm9/source/romBrowser/SdFolder.cpp
+++ b/arm9/source/romBrowser/SdFolder.cpp
@@ -21,7 +21,8 @@ std::unique_ptr<const FileInfo*[]> SdFolder::FilterAndSort(
     for (int i = 0; i < _fileCount; i++)
     {
         const FileInfo* file = _files[i];
-        bool isHidden = file->GetFileName()[0] == '.' || file->IsHidden();
+        const auto filename = file->GetFileName();
+        bool isHidden = filename[0] == '.' || filename[0] == '_' || file->IsHidden();
         auto classification = file->GetFileType()->GetClassification();
         if (classification != FileTypeClassification::Unknown &&
             (!isHidden || filterSortParams.includeHiddenFiles))


### PR DESCRIPTION
Background: 7c06abf224fbf48da7c6c436f62f5cf43f4179ed automatically hides files/folders that start with a `.` or have the FAT32 hidden attribute set.

This commit extends this to also hide files/folders starting with a `_` since these are generally system files that don't need to be accessible via the UI.

Fixes #13