### PR TITLE
Allow overriding NDS file associations

### DIFF
--- a/arm9/source/romBrowser/FileType/ExtensionFileTypeProvider.cpp
+++ b/arm9/source/romBrowser/FileType/ExtensionFileTypeProvider.cpp
@@ -29,6 +29,10 @@ ExtensionFileTypeProvider::ExtensionFileTypeProvider(const AppSettings& appSetti
         {
             baseFileType = &GbaFileType::sInstance;
         }
+        else if (isNdsExtension(appSettings.fileAssociations[i].extension))
+        {
+            baseFileType = &NdsFileType::sInstance;
+        }
         _customFileTypes[i] = CustomFileType(&appSettings.fileAssociations[i], baseFileType);
     }
 }
@@ -40,17 +44,17 @@ const FileType* ExtensionFileTypeProvider::GetFileType(const TCHAR* path) const
     {
         extension++; // skip over dot
 
-        if (isNdsExtension(extension))
-        {
-            return &NdsFileType::sInstance;
-        }
-
         for (u32 i = 0; i < _appSettings.numberOfFileAssociations; i++)
         {
             if (!strcasecmp(extension, _customFileTypes[i].GetShortName()))
             {
                 return &_customFileTypes[i];
             }
+        }
+
+        if (isNdsExtension(extension))
+        {
+            return &NdsFileType::sInstance;
         }
     }
 


### PR DESCRIPTION
I decided to play around with using nds-bootstrap via Pico Launcher and turns out its as easy as installing the forwarder pack and setting the file association:
```json
"fileAssociations": {
  "nds": {
    "appPath": "/_nds/ntr-forwarder/sdcard.nds"
  }
}
```

There's just two issues, A) Pico Launcher checks for NDS files before file associations and B) NDS file associations don't have icons. You can work around the former by using .app or .ids as your extension (supported by nds-bootstrap, not treated special by pico launcher) but the later requires a code change... 

From my testing this appears to work perfectly with all types of nds files, even homebrew just gets passed through.