### PR TITLE
Fix cheats panel layout and parser bounds check

### DIFF
--- a/arm9/source/cheats/UsrCheatRepository.cpp
+++ b/arm9/source/cheats/UsrCheatRepository.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
     auto entries = new CheatEntry[totalNumberOfItems];
     u32 entryCount = 0;
 
-    while (ptr < cheatData.get() + cheatDataLength)
+    while (ptr < cheatData.get() + cheatDataLength && entryCount < totalNumberOfItems)
     {
         u32 itemFlags = *(u32*)ptr;
         bool isCategory = ((itemFlags >> 28) & 1) == 1;

--- a/arm9/source/cheats/UsrCheatRepository.cpp
+++ b/arm9/source/cheats/UsrCheatRepository.cpp
@@ -107,20 +107,31 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
     // master codes
     ptr += 8 * 4;
 
+    const u8* endPtr = cheatData.get() + cheatDataLength;
+
+    if (totalNumberOfItems > 2000)
+    {
+        totalNumberOfItems = 2000;
+    }
+    if (totalNumberOfItems > (u32)(endPtr - ptr) / 4)
+    {
+        totalNumberOfItems = (u32)(endPtr - ptr) / 4;
+    }
+
     auto entries = new CheatEntry[totalNumberOfItems];
     u32 entryCount = 0;
 
-    while (ptr < cheatData.get() + cheatDataLength && entryCount < totalNumberOfItems)
+    while (ptr + 4 <= endPtr && entryCount < totalNumberOfItems)
     {
         u32 itemFlags = *(u32*)ptr;
         bool isCategory = ((itemFlags >> 28) & 1) == 1;
         if (isCategory)
         {
-            entries[entryCount++] = ParseCategory(ptr);
+            entries[entryCount++] = ParseCategory(ptr, endPtr);
         }
         else
         {
-            entries[entryCount++] = ParseCheat(ptr);
+            entries[entryCount++] = ParseCheat(ptr, endPtr);
         }
     }
 
@@ -158,8 +169,14 @@ const usr_cheat_index_entry_t* UsrCheatRepository::FindIndex(u32 gameCode, u32 h
     return nullptr;
 }
 
-CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr) const
+CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr, const u8* endPtr) const
 {
+    if (ptr + 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+
     // flags
     u32 itemFlags = *(u32*)ptr;
     ptr += 4;
@@ -168,53 +185,129 @@ CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr) const
 
     // item name
     const char* itemName = (const char*)ptr;
-    ptr += strlen(itemName) + 1;
+    u32 nameLen = 0;
+    while (ptr + nameLen < endPtr && ptr[nameLen] != '\0')
+    {
+        nameLen++;
+    }
+    if (ptr + nameLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += nameLen + 1;
 
     // item description
     const char* itemDescription = (const char*)ptr;
-    ptr += strlen(itemDescription) + 1;
+    u32 descLen = 0;
+    while (ptr + descLen < endPtr && ptr[descLen] != '\0')
+    {
+        descLen++;
+    }
+    if (ptr + descLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += descLen + 1;
 
     // padding
     ptr = (u8*)(((u32)ptr + 3) & ~3); // 32-bit align
+    if (ptr > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+
+    if (numberOfItems > 1000)
+    {
+        numberOfItems = 1000;
+    }
+    if (numberOfItems > (u32)(endPtr - ptr) / 4)
+    {
+        numberOfItems = (u32)(endPtr - ptr) / 4;
+    }
 
     auto entries = new CheatEntry[numberOfItems];
+    u32 parsedCount = 0;
     for (u32 i = 0; i < numberOfItems; i++)
     {
-        u32 itemFlags = *(u32*)ptr;
-        bool isCategory = ((itemFlags >> 28) & 1) == 1;
-        if (isCategory)
+        if (ptr >= endPtr)
         {
-            entries[i] = ParseCategory(ptr);
+            break;
+        }
+        u32 subFlags = *(u32*)ptr;
+        bool isSubCategory = ((subFlags >> 28) & 1) == 1;
+        if (isSubCategory)
+        {
+            entries[parsedCount++] = ParseCategory(ptr, endPtr);
         }
         else
         {
-            entries[i] = ParseCheat(ptr);
+            entries[parsedCount++] = ParseCheat(ptr, endPtr);
         }
     }
 
-    return CheatEntry(itemName, itemDescription, isMaxOneCheatActive, entries, numberOfItems);
+    return CheatEntry(itemName, itemDescription, isMaxOneCheatActive, entries, parsedCount);
 }
 
-CheatEntry UsrCheatRepository::ParseCheat(u8*& ptr) const
+CheatEntry UsrCheatRepository::ParseCheat(u8*& ptr, const u8* endPtr) const
 {
+    if (ptr + 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+
     // flags
     u32* flagsPtr = (u32*)ptr;
     ptr += 4;
 
     // item name
     const char* itemName = (const char*)ptr;
-    ptr += strlen(itemName) + 1;
+    u32 nameLen = 0;
+    while (ptr + nameLen < endPtr && ptr[nameLen] != '\0')
+    {
+        nameLen++;
+    }
+    if (ptr + nameLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += nameLen + 1;
 
     // item description
     const char* itemDescription = (const char*)ptr;
-    ptr += strlen(itemDescription) + 1;
+    u32 descLen = 0;
+    while (ptr + descLen < endPtr && ptr[descLen] != '\0')
+    {
+        descLen++;
+    }
+    if (ptr + descLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += descLen + 1;
 
     // padding
     ptr = (u8*)(((u32)ptr + 3) & ~3); // 32-bit align
+    if (ptr + 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
 
     // number of code words
     u32 numberOfCodeWords = *(u32*)ptr;
     ptr += 4;
+
+    if (ptr + numberOfCodeWords * 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
 
     const void* cheatData = ptr;
 

--- a/arm9/source/cheats/UsrCheatRepository.h
+++ b/arm9/source/cheats/UsrCheatRepository.h
@@ -23,6 +23,6 @@ private:
 
     std::unique_ptr<GameCheats> GetCheatsForGame(u32 gameCode, u32 headerCrc32) const;
     const usr_cheat_index_entry_t* FindIndex(u32 gameCode, u32 headerCrc32) const;
-    CheatEntry ParseCategory(u8*& ptr) const;
-    CheatEntry ParseCheat(u8*& ptr) const;
+    CheatEntry ParseCategory(u8*& ptr, const u8* endPtr) const;
+    CheatEntry ParseCheat(u8*& ptr, const u8* endPtr) const;
 };

--- a/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
+++ b/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
@@ -17,8 +17,9 @@
 #define TITLE_LABEL_X               20
 #define TITLE_LABEL_Y               16
 
-#define CATEGORY_NAME_LABEL_X       (TITLE_LABEL_X + 43)
+#define CATEGORY_NAME_LABEL_X       (TITLE_LABEL_X + 38)
 #define CATEGORY_NAME_LABEL_Y       (TITLE_LABEL_Y + 1)
+#define CATEGORY_NAME_LABEL_WIDTH   85
 
 #define NO_CHEATS_FOUND_LABEL_X     20
 #define NO_CHEATS_FOUND_LABEL_Y     36
@@ -26,7 +27,7 @@
 #define DESCRIPTION_LABEL_X         16
 #define DESCRIPTION_LABEL_Y         147
 
-#define UP_BUTTON_X                 212
+#define UP_BUTTON_X                 221
 #define UP_BUTTON_Y                 (TITLE_LABEL_Y - 7)
 
 #define LIST_X                      16
@@ -39,7 +40,7 @@ CheatsBottomSheetView::CheatsBottomSheetView(SharedPtr<CheatsViewModel> viewMode
     FocusManager* focusManager)
     : _viewModel(std::move(viewModel))
     , _titleLabel(Label2DView::CreateShared(64, 16, 25, fontRepository->GetFont(FontType::Medium11)))
-    , _secondaryLabel(Label2DView::CreateShared(153, 16, 64, fontRepository->GetFont(FontType::Regular10)))
+    , _secondaryLabel(Label2DView::CreateShared(CATEGORY_NAME_LABEL_WIDTH, 16, 64, fontRepository->GetFont(FontType::Regular10)))
     , _descriptionLabel(Label2DView::CreateShared(224, 16, 256, fontRepository->GetFont(FontType::Medium7_5)))
     , _cheatListRecycler(RecyclerView::CreateShared(
         LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT, RecyclerView::Mode::VerticalList))
@@ -53,7 +54,7 @@ CheatsBottomSheetView::CheatsBottomSheetView(SharedPtr<CheatsViewModel> viewMode
     , _focusManager(focusManager)
 {
     _titleLabel->SetText(u"Cheats");
-    _secondaryLabel->SetText(u"No cheats found.");
+    _secondaryLabel->SetText(u"No cheats found");
     _secondaryLabel->SetEllipsisStyle(LabelView::EllipsisStyle::Ellipsis);
     _descriptionLabel->SetEllipsisStyle(LabelView::EllipsisStyle::Marquee);
     _descriptionLabel->SetText(u"");
@@ -226,6 +227,11 @@ void CheatsBottomSheetView::Draw(GraphicsContext& graphicsContext)
     graphicsContext.ResetClipArea();
 }
 
+void CheatsBottomSheetView::Focus(FocusManager& focusManager)
+{
+    _cheatListRecycler->Focus(focusManager);
+}
+
 SharedPtr<View> CheatsBottomSheetView::MoveFocus(const SharedPtr<View>& currentFocus, FocusMoveDirection direction, View* source)
 {
     if (!currentFocus)
@@ -297,7 +303,8 @@ void CheatsBottomSheetView::UpdateDescriptionText()
         auto cheatCategory = _viewModel->GetCurrentCheatCategory();
         u32 numberOfSubEntries = 0;
         auto subEntries = cheatCategory->GetSubEntries(numberOfSubEntries);
-        _descriptionLabel->SetText(subEntries[selectedItem].GetDescription());
+        const char* desc = subEntries[selectedItem].GetDescription();
+        _descriptionLabel->SetText(desc ? desc : "");
     }
 }
 

--- a/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
+++ b/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
@@ -303,8 +303,15 @@ void CheatsBottomSheetView::UpdateDescriptionText()
         auto cheatCategory = _viewModel->GetCurrentCheatCategory();
         u32 numberOfSubEntries = 0;
         auto subEntries = cheatCategory->GetSubEntries(numberOfSubEntries);
-        const char* desc = subEntries[selectedItem].GetDescription();
-        _descriptionLabel->SetText(desc ? desc : "");
+        if (subEntries && selectedItem < (int)numberOfSubEntries)
+        {
+            const char* desc = subEntries[selectedItem].GetDescription();
+            _descriptionLabel->SetText(desc ? desc : "");
+        }
+        else
+        {
+            _descriptionLabel->SetText("");
+        }
     }
 }
 

--- a/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.h
+++ b/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.h
@@ -25,10 +25,7 @@ public:
     SharedPtr<View> MoveFocus(const SharedPtr<View>& currentFocus, FocusMoveDirection direction, View* source) override;
     bool HandleInput(const InputProvider& inputProvider, FocusManager& focusManager) override;
 
-    void Focus(FocusManager& focusManager) override
-    {
-        _cheatListRecycler->Focus(focusManager);
-    }
+    void Focus(FocusManager& focusManager) override;
 
 protected:
     void Close() override;


### PR DESCRIPTION
- Fix cheat parser writing past allocated array on malformed usrcheat.dat
- Fix category name label overlapping the up button
- Add null guard for missing cheat entry descriptions