### PR TITLE
Fix cheats panel layout and harden the cheat parser

### DIFF
--- a/arm9/source/cheats/CheatEntry.h
+++ b/arm9/source/cheats/CheatEntry.h
@@ -5,23 +5,27 @@ class CheatEntry
 {
 public:
     /// @brief Dummy empty constructor.
+    ///        Produces an invalid entry, used internally to signal that parsing malformed
+    ///        cheat data failed. See \see IsValid().
     CheatEntry()
-        : _isCheatCategory(false), _flagsPointer(nullptr), _cheatData(nullptr), _cheatDataLength(0) { }
+        : _isCheatCategory(false), _flagsPointer(nullptr), _cheatData(nullptr), _cheatDataLength(0)
+        , _isValid(false) { }
 
     /// @brief Constructor for a cheat.
     CheatEntry(const char* name, const char* description, u32* flagsPointer, const void* cheatData, u32 cheatDataLength)
         : _name(name), _description(description), _isCheatCategory(false), _flagsPointer(flagsPointer)
-        , _cheatData(cheatData), _cheatDataLength(cheatDataLength) { }
+        , _cheatData(cheatData), _cheatDataLength(cheatDataLength), _isValid(true) { }
 
     /// @brief Constructor for a category.
     CheatEntry(const char* name, const char* description, bool isMaxOneCheatActive, CheatEntry* subEntries, u32 numberOfSubEntries)
         : _name(name), _description(description), _isCheatCategory(true), _isMaxOneCheatActive(isMaxOneCheatActive)
-        , _subEntries(subEntries), _numberOfSubEntries(numberOfSubEntries) { }
+        , _subEntries(subEntries), _numberOfSubEntries(numberOfSubEntries), _isValid(true) { }
 
     CheatEntry(const CheatEntry& other) = delete;
 
     CheatEntry(CheatEntry&& other)
         : _isCheatCategory(false), _flagsPointer(nullptr), _cheatData(nullptr), _cheatDataLength(0)
+        , _isValid(false)
     {
         *this = std::move(other);
     }
@@ -66,6 +70,8 @@ public:
             _cheatDataLength = other._cheatDataLength;
             other._cheatDataLength = 0;
         }
+        _isValid = other._isValid;
+        other._isValid = false;
 
         return *this;
     }
@@ -140,6 +146,15 @@ public:
         return _isCheatCategory;
     }
 
+    /// @brief Indicates if this entry was parsed successfully from cheat data.
+    /// @return \c true when this entry is valid and safe to use, or \c false when it is a dummy
+    ///         entry produced when parsing malformed cheat data failed. Callers must not call
+    ///         \see GetIsCheatActive() or \see SetIsCheatActive() on an invalid entry.
+    bool IsValid() const
+    {
+        return _isValid;
+    }
+
     /// @brief Indicates if this entry is a cheat category in which only one cheat is allowed to be on at a time or not.
     /// @return \c true when this entry is a cheat category in which only one cheat is allowed
     ///         to be active at a time, or \c false otherwise.
@@ -187,4 +202,6 @@ private:
             u32 _numberOfSubEntries;
         };
     };
+
+    bool _isValid;
 };

--- a/arm9/source/cheats/UsrCheatRepository.cpp
+++ b/arm9/source/cheats/UsrCheatRepository.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
     auto entries = new CheatEntry[totalNumberOfItems];
     u32 entryCount = 0;
 
-    while (ptr < cheatData.get() + cheatDataLength)
+    while (ptr < cheatData.get() + cheatDataLength && entryCount < totalNumberOfItems)
     {
         u32 itemFlags = *(u32*)ptr;
         bool isCategory = ((itemFlags >> 28) & 1) == 1;

--- a/arm9/source/cheats/UsrCheatRepository.cpp
+++ b/arm9/source/cheats/UsrCheatRepository.cpp
@@ -107,21 +107,31 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
     // master codes
     ptr += 8 * 4;
 
+    const u8* endPtr = cheatData.get() + cheatDataLength;
+
+    if (totalNumberOfItems > 2000)
+    {
+        totalNumberOfItems = 2000;
+    }
+    if (totalNumberOfItems > (u32)(endPtr - ptr) / 4)
+    {
+        totalNumberOfItems = (u32)(endPtr - ptr) / 4;
+    }
+
     auto entries = new CheatEntry[totalNumberOfItems];
     u32 entryCount = 0;
 
-    while (ptr < cheatData.get() + cheatDataLength && entryCount < totalNumberOfItems)
+    while (ptr + 4 <= endPtr && entryCount < totalNumberOfItems)
     {
         u32 itemFlags = *(u32*)ptr;
         bool isCategory = ((itemFlags >> 28) & 1) == 1;
-        if (isCategory)
+        CheatEntry entry = isCategory ? ParseCategory(ptr, endPtr) : ParseCheat(ptr, endPtr);
+        if (!entry.IsValid())
         {
-            entries[entryCount++] = ParseCategory(ptr);
+            LOG_ERROR("Malformed cheat data, stopping parse\n");
+            break;
         }
-        else
-        {
-            entries[entryCount++] = ParseCheat(ptr);
-        }
+        entries[entryCount++] = std::move(entry);
     }
 
     auto actualEntries = new CheatEntry[entryCount];
@@ -158,8 +168,14 @@ const usr_cheat_index_entry_t* UsrCheatRepository::FindIndex(u32 gameCode, u32 h
     return nullptr;
 }
 
-CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr) const
+CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr, const u8* endPtr) const
 {
+    if (ptr + 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+
     // flags
     u32 itemFlags = *(u32*)ptr;
     ptr += 4;
@@ -168,53 +184,128 @@ CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr) const
 
     // item name
     const char* itemName = (const char*)ptr;
-    ptr += strlen(itemName) + 1;
+    u32 nameLen = 0;
+    while (ptr + nameLen < endPtr && ptr[nameLen] != '\0')
+    {
+        nameLen++;
+    }
+    if (ptr + nameLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += nameLen + 1;
 
     // item description
     const char* itemDescription = (const char*)ptr;
-    ptr += strlen(itemDescription) + 1;
+    u32 descLen = 0;
+    while (ptr + descLen < endPtr && ptr[descLen] != '\0')
+    {
+        descLen++;
+    }
+    if (ptr + descLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += descLen + 1;
 
     // padding
     ptr = (u8*)(((u32)ptr + 3) & ~3); // 32-bit align
-
-    auto entries = new CheatEntry[numberOfItems];
-    for (u32 i = 0; i < numberOfItems; i++)
+    if (ptr > endPtr)
     {
-        u32 itemFlags = *(u32*)ptr;
-        bool isCategory = ((itemFlags >> 28) & 1) == 1;
-        if (isCategory)
-        {
-            entries[i] = ParseCategory(ptr);
-        }
-        else
-        {
-            entries[i] = ParseCheat(ptr);
-        }
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
     }
 
-    return CheatEntry(itemName, itemDescription, isMaxOneCheatActive, entries, numberOfItems);
+    if (numberOfItems > 1000)
+    {
+        numberOfItems = 1000;
+    }
+    if (numberOfItems > (u32)(endPtr - ptr) / 4)
+    {
+        numberOfItems = (u32)(endPtr - ptr) / 4;
+    }
+
+    auto entries = new CheatEntry[numberOfItems];
+    u32 parsedCount = 0;
+    for (u32 i = 0; i < numberOfItems; i++)
+    {
+        if (ptr + 4 > endPtr)
+        {
+            break;
+        }
+        u32 subFlags = *(u32*)ptr;
+        bool isSubCategory = ((subFlags >> 28) & 1) == 1;
+        CheatEntry entry = isSubCategory ? ParseCategory(ptr, endPtr) : ParseCheat(ptr, endPtr);
+        if (!entry.IsValid())
+        {
+            LOG_ERROR("Malformed cheat data, stopping parse of category '%s'\n", itemName);
+            break;
+        }
+        entries[parsedCount++] = std::move(entry);
+    }
+
+    return CheatEntry(itemName, itemDescription, isMaxOneCheatActive, entries, parsedCount);
 }
 
-CheatEntry UsrCheatRepository::ParseCheat(u8*& ptr) const
+CheatEntry UsrCheatRepository::ParseCheat(u8*& ptr, const u8* endPtr) const
 {
+    if (ptr + 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+
     // flags
     u32* flagsPtr = (u32*)ptr;
     ptr += 4;
 
     // item name
     const char* itemName = (const char*)ptr;
-    ptr += strlen(itemName) + 1;
+    u32 nameLen = 0;
+    while (ptr + nameLen < endPtr && ptr[nameLen] != '\0')
+    {
+        nameLen++;
+    }
+    if (ptr + nameLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += nameLen + 1;
 
     // item description
     const char* itemDescription = (const char*)ptr;
-    ptr += strlen(itemDescription) + 1;
+    u32 descLen = 0;
+    while (ptr + descLen < endPtr && ptr[descLen] != '\0')
+    {
+        descLen++;
+    }
+    if (ptr + descLen >= endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+    ptr += descLen + 1;
 
     // padding
     ptr = (u8*)(((u32)ptr + 3) & ~3); // 32-bit align
+    if (ptr + 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
 
     // number of code words
     u32 numberOfCodeWords = *(u32*)ptr;
     ptr += 4;
+
+    if (ptr + numberOfCodeWords * 4 > endPtr)
+    {
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
 
     const void* cheatData = ptr;
 

--- a/arm9/source/cheats/UsrCheatRepository.cpp
+++ b/arm9/source/cheats/UsrCheatRepository.cpp
@@ -89,14 +89,30 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
         return nullptr;
     }
 
+    const u8* endPtr = cheatData.get() + cheatDataLength;
     u8* ptr = cheatData.get();
 
     // game name
     const char* gameName = (const char*)ptr;
-    ptr += strlen(gameName) + 1;
+    while (ptr < endPtr && *ptr != '\0')
+    {
+        ptr++;
+    }
+    if (ptr == endPtr)
+    {
+        LOG_ERROR("Malformed cheat data: unterminated game name\n");
+        return nullptr;
+    }
+    ptr++;
 
-    // padding
-    ptr = (u8*)(((u32)ptr + 3) & ~3); // 32-bit align
+    u32 headerOffset = ((u32)(ptr - cheatData.get()) + 3) & ~3; // 32-bit align
+    constexpr u32 rootHeaderSize = sizeof(u32) + 8 * sizeof(u32);
+    if (headerOffset > cheatDataLength || cheatDataLength - headerOffset < rootHeaderSize)
+    {
+        LOG_ERROR("Malformed cheat data: incomplete game header\n");
+        return nullptr;
+    }
+    ptr = cheatData.get() + headerOffset;
 
     // flags
     u32 flags = *(u32*)ptr;
@@ -106,8 +122,6 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
 
     // master codes
     ptr += 8 * 4;
-
-    const u8* endPtr = cheatData.get() + cheatDataLength;
 
     if (totalNumberOfItems > 2000)
     {
@@ -125,7 +139,7 @@ std::unique_ptr<GameCheats> UsrCheatRepository::GetCheatsForGame(u32 gameCode, u
     {
         u32 itemFlags = *(u32*)ptr;
         bool isCategory = ((itemFlags >> 28) & 1) == 1;
-        CheatEntry entry = isCategory ? ParseCategory(ptr, endPtr) : ParseCheat(ptr, endPtr);
+        CheatEntry entry = isCategory ? ParseCategory(ptr, endPtr, 1) : ParseCheat(ptr, endPtr);
         if (!entry.IsValid())
         {
             LOG_ERROR("Malformed cheat data, stopping parse\n");
@@ -168,8 +182,15 @@ const usr_cheat_index_entry_t* UsrCheatRepository::FindIndex(u32 gameCode, u32 h
     return nullptr;
 }
 
-CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr, const u8* endPtr) const
+CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr, const u8* endPtr, u32 depth) const
 {
+    if (depth > MaxCategoryDepth)
+    {
+        LOG_ERROR("Malformed cheat data: category nesting is too deep\n");
+        ptr = const_cast<u8*>(endPtr);
+        return CheatEntry();
+    }
+
     if (ptr + 4 > endPtr)
     {
         ptr = const_cast<u8*>(endPtr);
@@ -237,7 +258,7 @@ CheatEntry UsrCheatRepository::ParseCategory(u8*& ptr, const u8* endPtr) const
         }
         u32 subFlags = *(u32*)ptr;
         bool isSubCategory = ((subFlags >> 28) & 1) == 1;
-        CheatEntry entry = isSubCategory ? ParseCategory(ptr, endPtr) : ParseCheat(ptr, endPtr);
+        CheatEntry entry = isSubCategory ? ParseCategory(ptr, endPtr, depth + 1) : ParseCheat(ptr, endPtr);
         if (!entry.IsValid())
         {
             LOG_ERROR("Malformed cheat data, stopping parse of category '%s'\n", itemName);
@@ -301,7 +322,7 @@ CheatEntry UsrCheatRepository::ParseCheat(u8*& ptr, const u8* endPtr) const
     u32 numberOfCodeWords = *(u32*)ptr;
     ptr += 4;
 
-    if (ptr + numberOfCodeWords * 4 > endPtr)
+    if (numberOfCodeWords > (u32)(endPtr - ptr) / 4)
     {
         ptr = const_cast<u8*>(endPtr);
         return CheatEntry();

--- a/arm9/source/cheats/UsrCheatRepository.h
+++ b/arm9/source/cheats/UsrCheatRepository.h
@@ -23,6 +23,6 @@ private:
 
     std::unique_ptr<GameCheats> GetCheatsForGame(u32 gameCode, u32 headerCrc32) const;
     const usr_cheat_index_entry_t* FindIndex(u32 gameCode, u32 headerCrc32) const;
-    CheatEntry ParseCategory(u8*& ptr) const;
-    CheatEntry ParseCheat(u8*& ptr) const;
+    CheatEntry ParseCategory(u8*& ptr, const u8* endPtr) const;
+    CheatEntry ParseCheat(u8*& ptr, const u8* endPtr) const;
 };

--- a/arm9/source/cheats/UsrCheatRepository.h
+++ b/arm9/source/cheats/UsrCheatRepository.h
@@ -17,12 +17,14 @@ public:
     void UpdateEnabledCheatsForGame(const std::unique_ptr<GameCheats>& cheats) const override;
 
 private:
+    static constexpr u32 MaxCategoryDepth = 7;
+
     std::unique_ptr<File> _usrCheatFile;
     std::unique_ptr<usr_cheat_index_entry_t[]> _sortedIndices;
     u32 _numberOfIndices;
 
     std::unique_ptr<GameCheats> GetCheatsForGame(u32 gameCode, u32 headerCrc32) const;
     const usr_cheat_index_entry_t* FindIndex(u32 gameCode, u32 headerCrc32) const;
-    CheatEntry ParseCategory(u8*& ptr, const u8* endPtr) const;
+    CheatEntry ParseCategory(u8*& ptr, const u8* endPtr, u32 depth) const;
     CheatEntry ParseCheat(u8*& ptr, const u8* endPtr) const;
 };

--- a/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
+++ b/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
@@ -17,8 +17,9 @@
 #define TITLE_LABEL_X               20
 #define TITLE_LABEL_Y               16
 
-#define CATEGORY_NAME_LABEL_X       (TITLE_LABEL_X + 43)
+#define CATEGORY_NAME_LABEL_X       (TITLE_LABEL_X + 38)
 #define CATEGORY_NAME_LABEL_Y       (TITLE_LABEL_Y + 1)
+#define CATEGORY_NAME_LABEL_WIDTH   85
 
 #define NO_CHEATS_FOUND_LABEL_X     20
 #define NO_CHEATS_FOUND_LABEL_Y     36
@@ -26,7 +27,7 @@
 #define DESCRIPTION_LABEL_X         16
 #define DESCRIPTION_LABEL_Y         147
 
-#define UP_BUTTON_X                 212
+#define UP_BUTTON_X                 221
 #define UP_BUTTON_Y                 (TITLE_LABEL_Y - 7)
 
 #define LIST_X                      16
@@ -39,7 +40,7 @@ CheatsBottomSheetView::CheatsBottomSheetView(SharedPtr<CheatsViewModel> viewMode
     FocusManager* focusManager)
     : _viewModel(std::move(viewModel))
     , _titleLabel(Label2DView::CreateShared(64, 16, 25, fontRepository->GetFont(FontType::Medium11)))
-    , _secondaryLabel(Label2DView::CreateShared(153, 16, 64, fontRepository->GetFont(FontType::Regular10)))
+    , _secondaryLabel(Label2DView::CreateShared(CATEGORY_NAME_LABEL_WIDTH, 16, 64, fontRepository->GetFont(FontType::Regular10)))
     , _descriptionLabel(Label2DView::CreateShared(224, 16, 256, fontRepository->GetFont(FontType::Medium7_5)))
     , _cheatListRecycler(RecyclerView::CreateShared(
         LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT, RecyclerView::Mode::VerticalList))
@@ -53,7 +54,7 @@ CheatsBottomSheetView::CheatsBottomSheetView(SharedPtr<CheatsViewModel> viewMode
     , _focusManager(focusManager)
 {
     _titleLabel->SetText(u"Cheats");
-    _secondaryLabel->SetText(u"No cheats found.");
+    _secondaryLabel->SetText(u"No cheats found");
     _secondaryLabel->SetEllipsisStyle(LabelView::EllipsisStyle::Ellipsis);
     _descriptionLabel->SetEllipsisStyle(LabelView::EllipsisStyle::Marquee);
     _descriptionLabel->SetText(u"");
@@ -226,6 +227,11 @@ void CheatsBottomSheetView::Draw(GraphicsContext& graphicsContext)
     graphicsContext.ResetClipArea();
 }
 
+void CheatsBottomSheetView::Focus(FocusManager& focusManager)
+{
+    _cheatListRecycler->Focus(focusManager);
+}
+
 SharedPtr<View> CheatsBottomSheetView::MoveFocus(const SharedPtr<View>& currentFocus, FocusMoveDirection direction, View* source)
 {
     if (!currentFocus)
@@ -297,7 +303,8 @@ void CheatsBottomSheetView::UpdateDescriptionText()
         auto cheatCategory = _viewModel->GetCurrentCheatCategory();
         u32 numberOfSubEntries = 0;
         auto subEntries = cheatCategory->GetSubEntries(numberOfSubEntries);
-        _descriptionLabel->SetText(subEntries[selectedItem].GetDescription());
+        const char* desc = subEntries[selectedItem].GetDescription();
+        _descriptionLabel->SetText(desc ? desc : "");
     }
 }
 

--- a/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
+++ b/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.cpp
@@ -303,8 +303,15 @@ void CheatsBottomSheetView::UpdateDescriptionText()
         auto cheatCategory = _viewModel->GetCurrentCheatCategory();
         u32 numberOfSubEntries = 0;
         auto subEntries = cheatCategory->GetSubEntries(numberOfSubEntries);
-        const char* desc = subEntries[selectedItem].GetDescription();
-        _descriptionLabel->SetText(desc ? desc : "");
+        if (subEntries && selectedItem < (int)numberOfSubEntries)
+        {
+            const char* desc = subEntries[selectedItem].GetDescription();
+            _descriptionLabel->SetText(desc ? desc : "");
+        }
+        else
+        {
+            _descriptionLabel->SetText("");
+        }
     }
 }
 

--- a/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.h
+++ b/arm9/source/romBrowser/views/cheats/CheatsBottomSheetView.h
@@ -25,10 +25,7 @@ public:
     SharedPtr<View> MoveFocus(const SharedPtr<View>& currentFocus, FocusMoveDirection direction, View* source) override;
     bool HandleInput(const InputProvider& inputProvider, FocusManager& focusManager) override;
 
-    void Focus(FocusManager& focusManager) override
-    {
-        _cheatListRecycler->Focus(focusManager);
-    }
+    void Focus(FocusManager& focusManager) override;
 
 protected:
     void Close() override;


### PR DESCRIPTION
Resubmission of #71, rebased on current develop.

- Fix a crash when a usrcheat.dat declares fewer entries than it actually contains.
- Stop the parser from reading past the end of the file on malformed data.
- Cap the entry count so a bad file can't eat all the memory.
- Long cheat names now ellipsize and descriptions scroll instead of overflowing the panel.

Tested on DSi hardware with a the [latest usrcheat.dat from DeadSkullzJr](https://gbatemp.net/threads/deadskullzjrs-nds-i-cheat-databases.488711/).