### PR TITLE
Keep focus in the list when leaving an empty folder

### DIFF
--- a/arm9/source/App.cpp
+++ b/arm9/source/App.cpp
@@ -331,6 +331,8 @@ void App::HandleNavigateTrigger()
 {
     if (!_romBrowserBottomScreenView->IsAppBarFocused(_focusManager))
         _focusManager.Unfocus();
+    else
+        _focusListAfterFolderLoad = true;
 }
 
 void App::HandleFolderLoadDoneTrigger()
@@ -346,8 +348,9 @@ void App::HandleFolderLoadDoneTrigger()
         _theme->GetRomBrowserViewFactory());
     _romBrowserTopScreenView->InitVram(_subVramContext);
     _romBrowserBottomScreenView->RomBrowserViewModelInvalidated(_mainVramContext);
-    if (!_focusManager.GetCurrentFocus())
+    if (_focusListAfterFolderLoad || !_focusManager.GetCurrentFocus())
         _romBrowserBottomScreenView->Focus(_focusManager);
+    _focusListAfterFolderLoad = false;
 }
 
 void App::HandleChangeDisplayModeTrigger(RomBrowserState newState)

--- a/arm9/source/App.h
+++ b/arm9/source/App.h
@@ -96,6 +96,12 @@ private:
     VramState _vramStateBeforeMakeBottomScreenView;
     VramState _vramStateAfterMakeBottomScreenView;
     bool _changeDisplayMode = false;
+    // Set when navigation starts while focus is on the app bar (the back arrow, or
+    // the fallback focus inside an empty folder), so the loaded folder moves the
+    // highlight onto the list. Focus stays on the button meanwhile - the app bar
+    // keeps drawing while the list is hidden - and is handed over once the new
+    // listing is ready. Consumed at FolderLoadDone.
+    bool _focusListAfterFolderLoad = false;
 
     ChipView::VramToken _chipViewVram;
     IconButton2DView::VramToken _iconButtonViewVram;


### PR DESCRIPTION
Going up from a folder with nothing in it leaves the highlight on the back button in the app bar instead of on the list. From there the dpad only walks the app bar buttons and A goes up again, so it feels like the launcher stopped responding. Someone reported it to me as "sometimes it can't go back to the upper folder like root unless you power off like few times", and that is what it looks like.

Inside an empty folder the list has no row to hold focus, so `Focus()` falls back to the app bar. On the way out, `HandleNavigateTrigger` only clears focus when it is not already in the app bar, and `HandleFolderLoadDoneTrigger` only moves focus when it is null. So it stays on the button.

The fix flags the handoff instead of clearing focus there, so the highlight stays on the button while the folder loads and moves onto the list when the new listing is ready.

One thing it also changes, because it is the same path: going up with the touch arrow now ends with the highlight on the list, and pressing A twice on the back arrow opens the first entry instead of climbing a second level. B from the list does the same job so I think it reads fine, but tell me if you would rather keep the old behaviour for the arrow.

I reproduced it and tested the fix on a DS Lite with a build of this branch.