### PR TITLE
Save a screenshot of both screens by holding START

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Screenshots of both screens, saved to /_pico/screenshots by holding START - by @rasalopa
 - Support for custom BMP icons for games and folders - by @tasken
 - Support for custom NDS banners (custom titles, subtitles and animated icons) for games and folders - by @tasken
 - Theme selector

--- a/arm9/source/App.cpp
+++ b/arm9/source/App.cpp
@@ -41,6 +41,7 @@ App::App(IAppSettingsService& appSettingsService, IBgmService& bgmService)
     , _texturePaletteVram((vu16*)0x6880000)
     , _mainVramContext(nullptr, &_mainObjVram, &_textureVram, &_texturePaletteVram)
     , _subVramContext(nullptr, &_subObjVram, nullptr, nullptr)
+    , _screenshot(&_ioTaskQueue, &_mainObjVram, &_mainObjDialogVram, &_subObjVram)
     , _appSettingsService(appSettingsService)
     , _bgmService(bgmService)
     , _inputProvider(&_keyInputSource, &_touchInputSource)
@@ -191,7 +192,6 @@ void App::Run()
 
 void App::MainLoop()
 {
-    bool fadeIn = true;
     int fadeWaitFrames = SPLASH_FRAMES;
     while (true)
     {
@@ -209,7 +209,7 @@ void App::MainLoop()
                 break;
             }
         }
-        else if (fadeIn)
+        else if (_fadeIn)
         {
             if (fadeWaitFrames)
             {
@@ -222,7 +222,7 @@ void App::MainLoop()
                 bool fadeComplete = _fadeAnimator.Update();
                 if (fadeComplete)
                 {
-                    fadeIn = false;
+                    _fadeIn = false;
                     REG_BLDCNT_SUB = 0;
                     REG_DISPCNT_SUB &= ~(1 << 9);
                     REG_MASTER_BRIGHT = 0;
@@ -377,6 +377,10 @@ void App::HandleChangeDisplayModeTrigger(RomBrowserState newState)
 
 void App::Update()
 {
+    // Copying the captured frame out of vram is far too long for vblank, so it
+    // happens here, in the visible period.
+    _screenshot.Update();
+
     const auto& stateMachine = _romBrowserController.GetStateMachine();
     _romBrowserController.Update();
     auto curState = stateMachine.GetCurrentState();
@@ -468,6 +472,9 @@ void App::Draw()
 void App::VBlank()
 {
     dma_ntrStopDirect(0); // stop hblank dma
+    // Arms a pending bottom screen capture for the frame whose sprites go up a
+    // few lines down, so the saved image is the one the player asked for.
+    _screenshot.VBlankBegin();
     _inputProvider.Sample();
     _inputRepeater.Update();
     _mainOam.Apply(GFX_OAM_MAIN);
@@ -480,7 +487,13 @@ void App::VBlank()
         rtos_enableIrqMask(RTOS_IRQ_VCOUNT);
         _vcountIrqStarted = true;
     }
-    _mainObjPltt.VBlank();
+    // Left alone from the moment the top half is queued until the mirror is
+    // handed back, which is wider than the frame the palette is actually the
+    // other screen's - on the first of those frames nothing has been mirrored
+    // yet, since that happens further down this same function. Wider on
+    // purpose, for the reason in Draw: too narrow writes into a saved image.
+    if (!_screenshot.IsMirroringMainEngine())
+        _mainObjPltt.VBlank();
 
     if (_topBackground)
         _topBackground->VBlank();
@@ -489,13 +502,29 @@ void App::VBlank()
 
     _dialogPresenter.VBlank();
 
-    if (_romBrowserBottomScreenViewModel.IsRomBrowserVisible())
+    // While a screenshot borrows sub background vram, the top screen view has
+    // to sit out: it uploads the selected cover there and marks it done, so an
+    // upload during those frames would be lost for good. Skipping means it
+    // simply retries once the block is back.
+    if (_romBrowserBottomScreenViewModel.IsRomBrowserVisible() && !_screenshot.IsBusy())
     {
         _romBrowserTopScreenView->VBlank();
     }
     _romBrowserBottomScreenView->VBlank();
 
     _vblankTextureLoader.VBlank();
+
+    // Mirroring the sub engine onto the main one has to be the last word on the
+    // frame: it needs this frame's sub sprites uploaded, and every register it
+    // copies would otherwise be written over again below. The cover's matrix and
+    // window cannot be read back off the sub engine, so the view that computes
+    // them restates them in between.
+    if (_screenshot.MirrorSubEngineIfPending())
+    {
+        if (_romBrowserTopScreenView)
+            _romBrowserTopScreenView->MirrorToMainEngine();
+        _screenshot.ArmMirroredCapture();
+    }
 }
 
 void App::StoreVramState(VramState& vramState) const
@@ -516,6 +545,49 @@ void App::RestoreVramState(const VramState& vramState)
 
 void App::HandleInput()
 {
+    // Hold START to save both screens. One key rather than one per screen, and
+    // not SELECT: the dsi changes its brightness with SELECT and the volume
+    // buttons, and those are not readable in ds mode, so a player adjusting
+    // brightness would be taking screenshots without asking for any. START does
+    // nothing on any model of the family while software is running.
+    //
+    // The hold has to begin here: counting only once the key has been seen up
+    // means a hold that started before the launcher did cannot be read as a
+    // request, whatever it is held for. Counting frames of Current() rather
+    // than using Triggered() keeps one hold to one shot.
+    //
+    // What named this case was the 3ds, where holding START from the home menu
+    // is how a ds game is started at its native resolution. Whether the key can
+    // still be down by the time this runs is left open on purpose: it was not
+    // reproducible on the console it was tried on, which restarts rather than
+    // reaching the launcher if START is never released, and one console is not
+    // evidence about the rest. The guard is cheap and it also covers the cases
+    // that do not need that question answered - a key that sticks, a thumb
+    // resting on it, arriving here from another launcher.
+    //
+    // And no frames are counted while the opening fade is running, because that
+    // fade writes master brightness every frame, after this - the same register
+    // the capture blacks the bottom screen out with. A capture that started in
+    // there would have its blackout overwritten every frame, and worse, would
+    // save a half faded brightness and put it back once the fade had stopped
+    // writing: the bottom screen would then stay dimmed for the rest of the
+    // session, with nothing left to correct it.
+    //
+    // The test sits after the armed one on purpose. Suppressing the count is
+    // not the same as arming: doing it in the branch above would mark a key
+    // that is still held as armed, which is exactly what that branch exists to
+    // prevent.
+    if (!_inputRepeater.Current(InputKey::Start))
+    {
+        _screenshotHoldFrames = 0;
+        _screenshotHoldArmed = true;
+    }
+    else if (_screenshotHoldArmed && !_fadeIn &&
+        ++_screenshotHoldFrames == kScreenshotHoldFrames)
+    {
+        _screenshot.RequestBothScreens();
+    }
+
     _focusManager.Update(_inputRepeater);
     Point touchPoint;
     if (_inputRepeater.Triggered(InputKey::Touch) &&

--- a/arm9/source/App.cpp
+++ b/arm9/source/App.cpp
@@ -127,6 +127,12 @@ void App::Run()
 
     LoadTheme();
 
+    // Made before the vram states are stored, so the texture behind its text is
+    // part of what a display mode change restores instead of being dropped by it.
+    _toast = ToastView::CreateShared(&_theme->GetMaterialColorScheme(),
+        _theme->GetFontRepository(), &_vblankTextureLoader);
+    _toast->InitVram(_mainVramContext);
+
     _ioTaskQueue.StartThread(1, _ioTaskThreadStack, sizeof(_ioTaskThreadStack));
     _bgTaskQueue.StartThread(2, _bgTaskThreadStack, sizeof(_bgTaskThreadStack));
 
@@ -381,6 +387,28 @@ void App::Update()
     // happens here, in the visible period.
     _screenshot.Update();
 
+    // The io thread is what finishes a capture, so the answer turns up a few
+    // frames after the shutter. Saying so only once it is on the card means the
+    // message is true, and it also puts it safely outside the picture.
+    if (_toast)
+    {
+        switch (Screenshot::TakeResult())
+        {
+            case Screenshot::Result::Saved:
+                _toast->Show("Screenshot saved");
+                break;
+            case Screenshot::Result::Failed:
+                _toast->Show("Couldn't save the screenshot");
+                break;
+            case Screenshot::Result::Busy:
+                _toast->Show("Still saving the last one");
+                break;
+            case Screenshot::Result::None:
+                break;
+        }
+        _toast->Update();
+    }
+
     const auto& stateMachine = _romBrowserController.GetStateMachine();
     _romBrowserController.Update();
     auto curState = stateMachine.GetCurrentState();
@@ -464,6 +492,23 @@ void App::Draw()
 
     _dialogPresenter.Draw(mainGraphicsContext);
 
+    // Last, so nothing the browser draws afterwards can land on top of it. And
+    // not at all while a screenshot has this engine: on the frame it is actually
+    // mirrored, anything of ours drawn here would end up in that picture instead
+    // of on this one.
+    //
+    // The test is deliberately wider than that one frame - it is true from the
+    // moment the top half is queued until the mirror is handed back. Being too
+    // wide costs a frame or two of a message that is inside the capture's flash
+    // anyway; being too narrow puts the message inside a saved screenshot.
+    if (_toast)
+    {
+        if (_screenshot.IsMirroringMainEngine())
+            _toast->Suppress();
+        else
+            _toast->Draw(mainGraphicsContext);
+    }
+
     _mainObjPltt.EndOfFrame();
 
     Gx::SwapBuffers(GX_XLU_SORT_MANUAL, GX_DEPTH_MODE_Z);
@@ -501,6 +546,12 @@ void App::VBlank()
         _bottomBackground->VBlank();
 
     _dialogPresenter.VBlank();
+
+    // Above the mirroring below, and it has to stay there: this writes the main
+    // engine's window and display control registers, which from the next
+    // statement on belong to the capture.
+    if (_toast)
+        _toast->VBlank();
 
     // While a screenshot borrows sub background vram, the top screen view has
     // to sit out: it uploads the selected cover there and marks it done, so an

--- a/arm9/source/App.h
+++ b/arm9/source/App.h
@@ -30,6 +30,7 @@
 #include "themes/ITheme.h"
 #include "animation/Animator.h"
 #include "Screenshot.h"
+#include "gui/views/ToastView.h"
 
 class alignas(32) App : public IProcess
 {
@@ -82,6 +83,7 @@ private:
     /// False until START has been seen up, so a hold that started before the
     /// launcher did cannot count as a request.
     bool _screenshotHoldArmed = false;
+    SharedPtr<ToastView> _toast;
 
     std::unique_ptr<ITheme> _theme;
     std::unique_ptr<IThemeBackground> _topBackground;

--- a/arm9/source/App.h
+++ b/arm9/source/App.h
@@ -29,6 +29,7 @@
 #include "DialogPresenter.h"
 #include "themes/ITheme.h"
 #include "animation/Animator.h"
+#include "Screenshot.h"
 
 class alignas(32) App : public IProcess
 {
@@ -66,6 +67,21 @@ private:
     u32 _ioTaskThreadStack[2048 / 4];
     TaskQueue<32, sizeof(TaskBase) + 32> _bgTaskQueue;
     u32 _bgTaskThreadStack[2048 / 4];
+
+    /// Visible periods START has to be held before both screens are saved.
+    static constexpr u32 kScreenshotHoldFrames = 30;
+
+    /// Whether the fade the launcher opens with is still running. A member
+    /// rather than a local of the loop because the screenshot shortcut has to
+    /// know: that fade writes master brightness every frame, which is the same
+    /// register a capture blacks the bottom screen out with.
+    bool _fadeIn = true;
+
+    Screenshot _screenshot;
+    u32 _screenshotHoldFrames = 0;
+    /// False until START has been seen up, so a hold that started before the
+    /// launcher did cannot count as a request.
+    bool _screenshotHoldArmed = false;
 
     std::unique_ptr<ITheme> _theme;
     std::unique_ptr<IThemeBackground> _topBackground;

--- a/arm9/source/Screenshot.cpp
+++ b/arm9/source/Screenshot.cpp
@@ -1,0 +1,755 @@
+#include "common.h"
+#include <string.h>
+#include <nds/arm9/cache.h>
+#include <libtwl/gfx/gfx.h>
+#include <libtwl/gfx/gfxBackground.h>
+#include <libtwl/gfx/gfxOam.h>
+#include <libtwl/gfx/gfxPalette.h>
+#include <libtwl/dma/dmaNitro.h>
+#include <libtwl/rtos/rtosIrq.h>
+#include "core/mini-printf.h"
+#include "fat/File.h"
+#include "Screenshot.h"
+
+#define SCREEN_WIDTH        256
+#define SCREEN_HEIGHT       192
+#define CAPTURE_BYTES       (SCREEN_WIDTH * SCREEN_HEIGHT * 2)
+#define CAPTURE_HALFWORDS   (CAPTURE_BYTES / 2)
+
+// LCDC windows of the two blocks used as capture destinations.
+#define VRAM_A_LCDC         ((vu16*)0x06800000)
+#define VRAM_C_LCDC         ((vu16*)0x06840000)
+#define VRAM_F_LCDC         ((vu16*)0x06890000)
+#define VRAM_G_LCDC         ((vu16*)0x06894000)
+#define VRAM_H_LCDC         ((vu16*)0x06898000)
+// The top capture writes into the upper 96 KB of block A, which leaves the flat
+// background texel the material theme keeps at offset 0 alone.
+#define VRAM_A_CAPTURE_OFFSET   0x8000
+
+// Extended background palettes are 8 KB per slot. Only slot 0 (the theme's
+// background) and slot 3 (the cover) are ever filled, and only the first
+// sub palette of each, so 512 bytes apiece is the whole job.
+#define EXT_PLTT_SLOT_SIZE  0x2000
+#define EXT_PLTT_COPY_BYTES 512
+// The two saved blocks are cache line aligned so their invalidate cannot reach
+// the members around them. That only holds while the copy is a whole number of
+// lines and no bigger than the arrays it fills.
+static_assert(EXT_PLTT_COPY_BYTES % 32 == 0, "ext palette copy must be whole cache lines");
+#define PLTT_BYTES          512
+#define PLTT_HALFWORDS      (PLTT_BYTES / 2)
+
+#define OAM_ENTRIES         128
+// Object tile numbers step in units of the boundary set in DISPCNT, which both
+// engines run at 128 bytes here, so a copy that lands at a multiple of 128 can
+// be pointed at by adding to the tile number.
+#define OBJ_TILE_BOUNDARY   128
+
+#define BMP_HEADER_SIZE     54
+#define BMP_ROW_BYTES       (SCREEN_WIDTH * 3) // multiple of 4 already, no padding
+
+#define SCREENSHOT_DIR      "/_pico/screenshots"
+#define MAX_SCREENSHOTS     1000
+
+// Capture the composited main engine output (BG + 3D + OBJ) at full size. Bit 31
+// starts it and the hardware clears it when the frame is done.
+#define DISPCAPCNT_BASE     ( 16            /* EVA: all of source A */        \
+                            | (0u << 8)     /* EVB: none of source B */       \
+                            | (3u << 20)    /* 256x192 */                     \
+                            | (0u << 24)    /* source A: BG + 3D + OBJ */     \
+                            | (0u << 29)    /* capture source A only */       \
+                            | (1u << 31))   /* enable */
+#define DISPCAPCNT_TO_C     (DISPCAPCNT_BASE | (2u << 16) | (0u << 18))
+#define DISPCAPCNT_TO_A     (DISPCAPCNT_BASE | (0u << 16) | (1u << 18))
+#define DISPCAPCNT_ENABLE   (1u << 31)
+
+// Engine B's registers sit at the same offsets as engine A's, 0x1000 higher, so
+// one list of offsets mirrors them. Deliberately not a block copy: offset 0x04
+// is DISPSTAT and VCOUNT, and 0x60 to 0x68 are the 3D and capture registers, so
+// copying the whole window would clear the capture enable bit we just set.
+namespace
+{
+    // The write only registers this path dirties. They read back as zero, so
+    // they cannot be saved and are put back by value.
+    //
+    // Zero is right for these because nobody else restates them each frame:
+    // the launcher does not touch the main engine's affine matrices, windows,
+    // mosaic or fade at all, and leaving the cover's matrix behind is not
+    // harmless - background 3 is enabled on the main engine, and an offset
+    // matrix makes it sample the dialog's map and draw bands over the browser.
+    const u16 kWriteOnlyRegs[] =
+    {
+        0x10, 0x12, 0x14,       0x18, 0x1A, 0x1C, 0x1E, // BG0-3 scroll, bar 0x16
+        0x20, 0x22, 0x24, 0x26, 0x28, 0x2A, 0x2C, 0x2E, // BG2 affine
+        0x30, 0x32, 0x34, 0x36, 0x38, 0x3A, 0x3C, 0x3E, // BG3 affine
+        0x40, 0x42, 0x44, 0x46,                         // window rectangles
+        0x4C,                                           // mosaic
+        0x54,                                           // blend fade
+    };
+    const u32 kWriteOnlyRegsCount = sizeof(kWriteOnlyRegs) / sizeof(kWriteOnlyRegs[0]);
+
+    // Zeroed on the way in and left alone on the way out, because background 1
+    // of this engine has an owner that does restate it: DialogPresenter writes
+    // its vertical offset every vblank with the bottom sheet's position, parked
+    // off screen when no sheet is up. Zeroing it in the restore scrolled the
+    // sheet's own map to the top of the screen, and the rows that land there
+    // are solid panel fill - so every screenshot painted a full screen slab
+    // over the bottom screen until the next vblank took it away.
+    //
+    // The mirror still needs it zeroed: background 1 of the sub engine is on
+    // during the splash, and the mirrored display control brings that bit with
+    // it.
+    const u16 kMirrorOnlyWriteOnlyRegs[] = { 0x16 }; // BG1's vertical offset
+    const u32 kMirrorOnlyWriteOnlyRegsCount =
+        sizeof(kMirrorOnlyWriteOnlyRegs) / sizeof(kMirrorOnlyWriteOnlyRegs[0]);
+
+    /// Fade to black at full strength: mode 2 in bits 14-15, factor 16.
+    #define REG_OFFSET_MASTER_BRIGHT    0x6C
+    #define MASTER_BRIGHT_BLACK         ((2u << 14) | 16u)
+
+    inline vu16& mainReg(u32 offset) { return *(vu16*)(0x04000000 + offset); }
+    inline vu16& subReg(u32 offset) { return *(vu16*)(0x04001000 + offset); }
+}
+
+namespace
+{
+    void writeU32(u8* p, u32 value)
+    {
+        p[0] = (u8)value;
+        p[1] = (u8)(value >> 8);
+        p[2] = (u8)(value >> 16);
+        p[3] = (u8)(value >> 24);
+    }
+
+    void writeU16(u8* p, u16 value)
+    {
+        p[0] = (u8)value;
+        p[1] = (u8)(value >> 8);
+    }
+
+    void fillBmpHeader(u8* header)
+    {
+        const u32 imageSize = BMP_ROW_BYTES * SCREEN_HEIGHT;
+        memset(header, 0, BMP_HEADER_SIZE);
+        header[0] = 'B';
+        header[1] = 'M';
+        writeU32(header + 2, BMP_HEADER_SIZE + imageSize);
+        writeU32(header + 10, BMP_HEADER_SIZE);
+        writeU32(header + 14, 40); // BITMAPINFOHEADER
+        writeU32(header + 18, SCREEN_WIDTH);
+        writeU32(header + 22, SCREEN_HEIGHT);
+        writeU16(header + 26, 1); // planes
+        writeU16(header + 28, 24); // bits per pixel
+        writeU32(header + 34, imageSize);
+    }
+
+    /// 5 bit channel to 8 bit, keeping white at 255.
+    inline u8 expand5(u32 value)
+    {
+        return (u8)((value << 3) | (value >> 2));
+    }
+
+    /// One row of the capture as BMP pixels. DS colour is 0bbbbbgggggrrrrr and
+    /// BMP wants blue, green, red per pixel.
+    void convertRow(const u16* src, u8* dst)
+    {
+        for (int x = 0; x < SCREEN_WIDTH; x++)
+        {
+            u16 colour = src[x];
+            dst[x * 3 + 0] = expand5((colour >> 10) & 0x1F);
+            dst[x * 3 + 1] = expand5((colour >> 5) & 0x1F);
+            dst[x * 3 + 2] = expand5(colour & 0x1F);
+        }
+    }
+
+    /// Everything the write needs that is too big for a 4KB worker stack: a FIL
+    /// is about a kilobyte on its own.
+    struct WriteScratch
+    {
+        File file;
+        FILINFO fileInfo;
+        u8 header[BMP_HEADER_SIZE];
+        u8 row[BMP_ROW_BYTES];
+    };
+
+    /// The number the first half of a pair claimed, so the second half can be
+    /// given the same one. Only ever touched from the io thread, which runs one
+    /// task at a time in the order they were queued, so the bottom half has
+    /// always finished before the top half reads this.
+    int sPairIndex = -1;
+
+    /// Lowest number neither screen has claimed, or -1 if the folder is full.
+    ///
+    /// One number per capture, not per screen. Deciding it per suffix would put
+    /// shot007_bot and shot007_top minutes apart while reading as two halves of
+    /// one moment, and deciding it twice for one gesture is worse: the bottom
+    /// half claims a number, and the top half then rejects that number because
+    /// the bottom file now exists, so a pair could never actually share one.
+    int findFreeIndex(WriteScratch* scratch, char* pathOut, u32 pathSize)
+    {
+        for (int i = 0; i < MAX_SCREENSHOTS; i++)
+        {
+            mini_snprintf(pathOut, pathSize, SCREENSHOT_DIR "/shot%03d_bot.bmp", i);
+            if (f_stat(pathOut, &scratch->fileInfo) == FR_OK)
+                continue;
+
+            mini_snprintf(pathOut, pathSize, SCREENSHOT_DIR "/shot%03d_top.bmp", i);
+            if (f_stat(pathOut, &scratch->fileInfo) == FR_OK)
+                continue;
+
+            return i;
+        }
+        return -1;
+    }
+
+    /// Runs on the io thread. Writes row by row on purpose: one big f_write
+    /// would hold the FatFs lock long enough for the music thread to starve.
+    bool writeBmp(const u16* pixels, bool topScreen, bool secondHalfOfPair)
+    {
+        // A first half claims a number and a second half inherits it, so a
+        // first half that gives up before claiming one must leave nothing to
+        // inherit. Without this it left the number of the last gesture that did
+        // claim, and files are opened with FA_CREATE_ALWAYS: reusing an old
+        // number does not fail, it overwrites a screenshot already on the card.
+        // The folder being full reaches this by itself, no fault required.
+        if (!secondHalfOfPair)
+            sPairIndex = -1;
+
+        auto* scratch = new WriteScratch();
+        if (!scratch)
+            return false;
+
+        FRESULT mkdirResult = f_mkdir(SCREENSHOT_DIR);
+        if (mkdirResult != FR_OK && mkdirResult != FR_EXIST)
+        {
+            LOG_ERROR("Screenshot: couldn't create " SCREENSHOT_DIR " (%d)\n", mkdirResult);
+            delete scratch;
+            return false;
+        }
+
+        char path[64];
+        int index = secondHalfOfPair && sPairIndex >= 0
+            ? sPairIndex
+            : findFreeIndex(scratch, path, sizeof(path));
+        if (index < 0)
+        {
+            LOG_ERROR("Screenshot: " SCREENSHOT_DIR " is full\n");
+            delete scratch;
+            return false;
+        }
+        sPairIndex = index;
+        mini_snprintf(path, sizeof(path), SCREENSHOT_DIR "/shot%03d_%s.bmp",
+            index, topScreen ? "top" : "bot");
+
+        if (scratch->file.Open(path, FA_WRITE | FA_CREATE_ALWAYS) != FR_OK)
+        {
+            LOG_ERROR("Screenshot: couldn't open %s\n", path);
+            delete scratch;
+            return false;
+        }
+
+        fillBmpHeader(scratch->header);
+        u32 written = 0;
+        bool ok = scratch->file.Write(scratch->header, BMP_HEADER_SIZE, written) == FR_OK &&
+            written == BMP_HEADER_SIZE;
+
+        // BMP rows run bottom to top.
+        for (int y = SCREEN_HEIGHT - 1; ok && y >= 0; y--)
+        {
+            convertRow(pixels + y * SCREEN_WIDTH, scratch->row);
+            ok = scratch->file.Write(scratch->row, BMP_ROW_BYTES, written) == FR_OK &&
+                written == BMP_ROW_BYTES;
+        }
+
+        // Close even when a write failed, and let its result count: a failure
+        // here means the data never reached the card.
+        if (scratch->file.Close() != FR_OK)
+            ok = false;
+
+        if (ok)
+        {
+            LOG_INFO("Screenshot: saved %s\n", path);
+        }
+        else
+        {
+            // The header already claims a full frame, so a half written file
+            // would open as a broken screenshot and keep its number forever.
+            f_unlink(path);
+            LOG_ERROR("Screenshot: failed to write %s\n", path);
+        }
+
+        delete scratch;
+        return ok;
+    }
+
+    /// How many of this class's write tasks have been handed to the io queue,
+    /// and how many have come back. One writer each - the main thread bumps the
+    /// first immediately before enqueueing, the io thread bumps the second as
+    /// the last thing its task does - so comparing them needs no lock and no
+    /// masked interrupts, only that a 32 bit aligned store is indivisible.
+    ///
+    /// File scope for the same reason as the result below: a queued task can
+    /// outlive the object that queued it.
+    volatile u32 sWritesQueued = 0;
+    volatile u32 sWritesDone = 0;
+
+    /// Records how a capture ended, for the one caller that polls it. Set from
+    /// the io thread when a file is written, and from the main thread on every
+    /// path that gives up before there is a file to write - without those, a
+    /// failure that happens early is completely silent, which is the opposite of
+    /// what publishing a result is for.
+    // Written by the io thread and read by the main one. A file scope variable
+    // rather than a member on purpose: a queued task that captured the object
+    // could outlive it and write into a Screenshot that is already gone. Losing
+    // a result to the read and clear race would cost one message, nothing more.
+    volatile Screenshot::Result sResult = Screenshot::Result::None;
+}
+
+Screenshot::~Screenshot()
+{
+    // Whatever was borrowed goes back, so a teardown mid capture cannot leave
+    // the engines pointed at each other's memory.
+    if (_screen == Screen::Top)
+    {
+        if (_state == State::Capturing)
+            RestoreMainEngine();
+        else if (_state == State::Arming)
+            mem_setVramAMapping(_savedVramAMapping);
+    }
+    else if (_state == State::Capturing)
+    {
+        mem_setVramCMapping(_savedVramCMapping);
+    }
+    delete[] _blockBackup;
+    delete[] _pixels;
+}
+
+void Screenshot::VBlankBegin()
+{
+    // The bottom screen is what the main engine already draws, so it is armed
+    // before this frame's sprites go up: those are the ones recorded.
+    if (_state != State::Arming || _screen != Screen::Bottom)
+        return;
+
+    _savedVramCMapping = mem_getVramCMapping();
+    mem_setVramCMapping(MEM_VRAM_C_LCDC);
+    REG_DISPCAPCNT = DISPCAPCNT_TO_C;
+    _captureWaitFrames = 0;
+    _state = State::Capturing;
+}
+
+bool Screenshot::MirrorSubEngineIfPending()
+{
+    // The top screen is mirrored onto the main engine instead of captured, and
+    // that needs the sub engine's sprites already uploaded, so it goes last in
+    // the frame.
+    if (_state != State::Arming || _screen != Screen::Top)
+        return false;
+
+    MirrorSubEngine();
+    return true;
+}
+
+void Screenshot::ArmMirroredCapture()
+{
+    if (_state != State::Arming || _screen != Screen::Top)
+        return;
+
+    // Last, so the write only registers the views just wrote are in place and
+    // this cannot be undone by anything else in the frame.
+    REG_DISPCNT = REG_DISPCNT_SUB & ~(1u << 3);
+    REG_DISPCAPCNT = DISPCAPCNT_TO_A;
+    _captureWaitFrames = 0;
+    _state = State::Capturing;
+}
+
+void Screenshot::PrepareTopCapture()
+{
+    // The sprite tiles have to end up somewhere the main engine can read, and
+    // block B is written from the io thread at unpredictable moments, so nothing
+    // already in it may be overwritten and put back - that would silently undo
+    // an icon upload. The gap between the two allocators is free by
+    // construction, and copied objects are pointed at it by adding to their
+    // tile numbers.
+    u32 spriteBytes = (_subObjVram->GetState() + 31) & ~31u;
+    if (spriteBytes > 16 * 1024)
+        spriteBytes = 16 * 1024;
+    u32 gapStart = (_mainObjVram->GetState() + OBJ_TILE_BOUNDARY - 1) & ~(OBJ_TILE_BOUNDARY - 1u);
+    u32 gapEnd = _mainObjDialogVram->GetState();
+    if (spriteBytes != 0 && (gapEnd <= gapStart || gapEnd - gapStart < spriteBytes))
+    {
+        LOG_ERROR("Screenshot: no room in main obj vram for %d sprite bytes\n", spriteBytes);
+        sResult = Result::Failed;
+        _pendingTop = false;
+        _topIsSecondHalf = false;
+        _state = State::Idle;
+        return;
+    }
+    _spriteTileOffset = gapStart;
+
+    _blockBackup = new(cache_align) u16[CAPTURE_HALFWORDS];
+    _pixels = new(cache_align) u16[CAPTURE_HALFWORDS];
+    if (!_blockBackup || !_pixels)
+    {
+        LOG_ERROR("Screenshot: couldn't allocate %d bytes\n", CAPTURE_BYTES * 2);
+        sResult = Result::Failed;
+        _pendingTop = false;
+        _topIsSecondHalf = false;
+        delete[] _blockBackup;
+        _blockBackup = nullptr;
+        delete[] _pixels;
+        _pixels = nullptr;
+        _state = State::Idle;
+        return;
+    }
+
+    // Block A receives the capture, so save the part being written to. The upper
+    // 96 KB is used, which leaves the single flat texel the material theme keeps
+    // at offset 0 alone.
+    _savedVramAMapping = mem_getVramAMapping();
+    mem_setVramAMapping(MEM_VRAM_AB_LCDC);
+    DC_InvalidateRange(_blockBackup, CAPTURE_BYTES);
+    dma_ntrCopy32(3, (const void*)(VRAM_A_LCDC + VRAM_A_CAPTURE_OFFSET / 2),
+        _blockBackup, CAPTURE_BYTES);
+
+    // Free space, so no backup and no race: nothing else is reading it.
+    if (spriteBytes != 0)
+    {
+        dma_ntrCopy32(3, (const void*)GFX_OBJ_SUB,
+            (void*)((vu8*)GFX_OBJ_MAIN + _spriteTileOffset), spriteBytes);
+    }
+
+    _state = State::Arming;
+}
+
+void Screenshot::MirrorSubEngine()
+{
+    _savedDispCnt = REG_DISPCNT;
+    _savedMasterBright = mainReg(REG_OFFSET_MASTER_BRIGHT);
+    for (u32 i = 0; i < kMirroredRegCount; i++)
+        _savedRegs[i] = mainReg(kMirroredRegs[i]);
+    for (u32 i = 0; i < PLTT_HALFWORDS; i++)
+    {
+        _savedBgPltt[i] = GFX_PLTT_BG_MAIN[i];
+        _savedObjPltt[i] = GFX_PLTT_OBJ_MAIN[i];
+    }
+    _savedVramCMapping = mem_getVramCMapping();
+    _savedVramFMapping = mem_getVramFMapping();
+    _savedVramGMapping = mem_getVramGMapping();
+    _savedVramHMapping = mem_getVramHMapping();
+
+    // The backgrounds cost nothing to hand over: block C is the one block either
+    // engine's backgrounds can read, and every base in the sub engine's
+    // registers means the same byte to the main engine, because only the main
+    // engine adds an offset of its own and that offset is zero here.
+    mem_setVramCMapping(MEM_VRAM_C_MAIN_BG_00000);
+
+    // F and G shadow the first 32 KB of that same window, so they have to move
+    // anyway - and the main engine needs extended palettes, which live in block
+    // H with no main engine mapping of their own. Only the first sub palette of
+    // slot 0 (the theme background) and slot 3 (the cover) is ever used.
+    mem_setVramFMapping(MEM_VRAM_FG_LCDC);
+    mem_setVramGMapping(MEM_VRAM_FG_LCDC);
+    // A palette slot has to sit at a fixed offset of its block, so these bytes
+    // cannot be dodged - and they are the bottom sheet's background tiles, which
+    // are uploaded once at startup and never again. Keep them.
+    DC_InvalidateRange(_savedFBytes, EXT_PLTT_COPY_BYTES);
+    DC_InvalidateRange(_savedGBytes, EXT_PLTT_COPY_BYTES);
+    dma_ntrCopy32(3, (const void*)VRAM_F_LCDC, _savedFBytes, EXT_PLTT_COPY_BYTES);
+    dma_ntrCopy32(3, (const void*)(VRAM_G_LCDC + EXT_PLTT_SLOT_SIZE / 2),
+        _savedGBytes, EXT_PLTT_COPY_BYTES);
+
+    mem_setVramHMapping(MEM_VRAM_H_LCDC);
+    dma_ntrCopy32(3, (const void*)VRAM_H_LCDC, (void*)VRAM_F_LCDC, EXT_PLTT_COPY_BYTES);
+    dma_ntrCopy32(3, (const void*)(VRAM_H_LCDC + (EXT_PLTT_SLOT_SIZE * 3) / 2),
+        (void*)(VRAM_G_LCDC + EXT_PLTT_SLOT_SIZE / 2), EXT_PLTT_COPY_BYTES);
+    mem_setVramFMapping(MEM_VRAM_FG_MAIN_BG_EXT_PLTT_SLOT_01);
+    mem_setVramGMapping(MEM_VRAM_FG_MAIN_BG_EXT_PLTT_SLOT_23);
+    mem_setVramHMapping(_savedVramHMapping);
+
+    // Palette ram is per engine hardware with no mapping at all, so it is
+    // copied. Entry 0 of the background palette carries the backdrop colour.
+    for (u32 i = 0; i < PLTT_HALFWORDS; i++)
+    {
+        GFX_PLTT_BG_MAIN[i] = GFX_PLTT_BG_SUB[i];
+        GFX_PLTT_OBJ_MAIN[i] = GFX_PLTT_OBJ_SUB[i];
+    }
+
+    // The gap was chosen a couple of frames ago and the io thread allocates
+    // object vram without warning, so make sure it is still free before the
+    // objects are pointed at it. Losing the sprites is better than drawing over
+    // an icon that was uploaded in the meantime.
+    bool spritesUsable = _spriteTileOffset >= _mainObjVram->GetState() &&
+        _spriteTileOffset < _mainObjDialogVram->GetState();
+
+    // The objects were uploaded to the sub engine's oam earlier this frame, so
+    // they are copied across with their tile numbers shifted to where the tiles
+    // were put. The main engine's own table comes back on its own next frame,
+    // when App applies its shadow copy again.
+    u16 tileShift = (u16)(_spriteTileOffset / OBJ_TILE_BOUNDARY);
+    for (u32 i = 0; i < OAM_ENTRIES; i++)
+    {
+        const vu16* src = GFX_OAM_SUB + i * 4;
+        vu16* dst = GFX_OAM_MAIN + i * 4;
+        u16 attr0 = src[0];
+        u16 attr2 = src[2];
+        // 0x0200 in attr0 is the disable bit for a plain object, so an
+        // unusable gap simply hides them all rather than drawing rubbish.
+        dst[0] = spritesUsable ? attr0 : (u16)(attr0 | 0x0200);
+        dst[1] = src[1];
+        dst[2] = (u16)((attr2 & ~0x3FFu) | (((attr2 & 0x3FFu) + tileShift) & 0x3FFu));
+        dst[3] = src[3];
+    }
+
+    for (u32 i = 0; i < kMirroredRegCount; i++)
+        mainReg(kMirroredRegs[i]) = subReg(kMirroredRegs[i]);
+
+    // The write only ones, by value. Start from zero so nothing is left over
+    // from a previous capture, then set what the top screen needs: none of its
+    // backgrounds scrolls, and the bitmap background a custom theme puts on
+    // background 2 is drawn with an identity matrix, which is also what the
+    // theme selector uses.
+    for (u32 i = 0; i < kWriteOnlyRegsCount; i++)
+        mainReg(kWriteOnlyRegs[i]) = 0;
+    for (u32 i = 0; i < kMirrorOnlyWriteOnlyRegsCount; i++)
+        mainReg(kMirrorOnlyWriteOnlyRegs[i]) = 0;
+    REG_BG2PA = 0x100;
+    REG_BG2PB = 0;
+    REG_BG2PC = 0;
+    REG_BG2PD = 0x100;
+    REG_BG2X = 0;
+    REG_BG2Y = 0;
+    REG_MOSAIC = 0;
+    REG_BLDY = 0;
+    // Background 3 and window 0 are the cover, whose numbers only the view that
+    // draws it knows, so it is asked to write them itself - see App::VBlank.
+
+    // The bottom screen belongs to this engine, and for the two frames the
+    // capture holds it there is nothing honest to show on it: the registers,
+    // the palettes and the oam all describe the other screen. That is what the
+    // player sees as a flash, and in the icon grid as cells that lose their
+    // fill and keep their outline - the grid's sprites drawn with the top
+    // screen's palette.
+    //
+    // So turn it off instead of showing borrowed state. Master brightness is
+    // the last thing in the display pipeline, after the capture unit reads the
+    // engine, so the recorded image should not care - and if it does, the saved
+    // bmp comes out black and says so plainly. Put back as the very last thing
+    // the restore does, so the screen never lights up on borrowed state.
+    mainReg(REG_OFFSET_MASTER_BRIGHT) = MASTER_BRIGHT_BLACK;
+
+    // The palette manager rewrites object palette rows partway down the frame,
+    // which would repaint the colours we just copied, inside the capture.
+    rtos_disableIrqMask(RTOS_IRQ_VCOUNT);
+    _vcountIrqSuppressed = true;
+}
+
+void Screenshot::RestoreMainEngine()
+{
+    for (u32 i = 0; i < kMirroredRegCount; i++)
+        mainReg(kMirroredRegs[i]) = _savedRegs[i];
+    for (u32 i = 0; i < kWriteOnlyRegsCount; i++)
+        mainReg(kWriteOnlyRegs[i]) = 0;
+    REG_DISPCNT = _savedDispCnt;
+    for (u32 i = 0; i < PLTT_HALFWORDS; i++)
+    {
+        GFX_PLTT_BG_MAIN[i] = _savedBgPltt[i];
+        GFX_PLTT_OBJ_MAIN[i] = _savedObjPltt[i];
+    }
+    mem_setVramCMapping(_savedVramCMapping);
+    // Put the borrowed background tiles back before the blocks go back to being
+    // background memory.
+    mem_setVramFMapping(MEM_VRAM_FG_LCDC);
+    mem_setVramGMapping(MEM_VRAM_FG_LCDC);
+    DC_FlushRange(_savedFBytes, EXT_PLTT_COPY_BYTES);
+    DC_FlushRange(_savedGBytes, EXT_PLTT_COPY_BYTES);
+    dma_ntrCopy32(3, _savedFBytes, (void*)VRAM_F_LCDC, EXT_PLTT_COPY_BYTES);
+    dma_ntrCopy32(3, _savedGBytes, (void*)(VRAM_G_LCDC + EXT_PLTT_SLOT_SIZE / 2),
+        EXT_PLTT_COPY_BYTES);
+    mem_setVramFMapping(_savedVramFMapping);
+    mem_setVramGMapping(_savedVramGMapping);
+    mem_setVramHMapping(_savedVramHMapping);
+    mem_setVramAMapping(_savedVramAMapping);
+    if (_vcountIrqSuppressed)
+    {
+        rtos_ackIrqMask(RTOS_IRQ_VCOUNT);
+        rtos_enableIrqMask(RTOS_IRQ_VCOUNT);
+        _vcountIrqSuppressed = false;
+    }
+    // Last, and on its own. This is what the player is looking at, so it comes
+    // off only once every piece of borrowed state is back: while it was part of
+    // the mirrored list it went back first, and the bottom screen then drew
+    // several lines with the other screen's palettes, with two of its own
+    // background blocks still lent out as palette slots, and for a moment with
+    // no block mapped at its background memory at all.
+    mainReg(REG_OFFSET_MASTER_BRIGHT) = _savedMasterBright;
+}
+
+void Screenshot::Update()
+{
+    if (_state == State::Requested)
+    {
+        if (_screen == Screen::Top)
+        {
+            PrepareTopCapture();
+            return;
+        }
+
+        // Both buffers are taken before anything touches vram: if the heap
+        // cannot spare them the capture is dropped and nothing is disturbed.
+        _blockBackup = new(cache_align) u16[CAPTURE_HALFWORDS];
+        _pixels = new(cache_align) u16[CAPTURE_HALFWORDS];
+        if (!_blockBackup || !_pixels)
+        {
+            LOG_ERROR("Screenshot: couldn't allocate %d bytes\n", CAPTURE_BYTES * 2);
+            sResult = Result::Failed;
+            _pendingTop = false;
+            delete[] _blockBackup;
+            _blockBackup = nullptr;
+            delete[] _pixels;
+            _pixels = nullptr;
+            _state = State::Idle;
+            return;
+        }
+
+        // Block C is still the sub engine's background and the capture is about
+        // to overwrite it. Nothing re-uploads that data, so keep a copy. Dma
+        // does not go through the data cache, so drop the lines covering the
+        // buffer first: otherwise a dirty one is written back over the copy.
+        DC_InvalidateRange(_blockBackup, CAPTURE_BYTES);
+        dma_ntrCopy32(3, (const void*)GFX_BG_SUB, _blockBackup, CAPTURE_BYTES);
+        _state = State::Arming;
+        return;
+    }
+
+    if (_state != State::Capturing)
+        return;
+
+    // The hardware clears the enable bit at the end of the captured frame.
+    bool gaveUp = false;
+    if (REG_DISPCAPCNT & DISPCAPCNT_ENABLE)
+    {
+        if (++_captureWaitFrames <= kCaptureWaitFrames)
+            return;
+
+        // Waiting forever is the one failure this class cannot come back from:
+        // IsBusy() would never drop, so the top screen would stop uploading
+        // covers and the vcount irq would stay masked, and the block would stay
+        // borrowed - a launcher broken until it is rebooted. Stop the capture
+        // unit by hand and put everything back, throwing the frame away.
+        LOG_ERROR("Screenshot: capture did not finish, giving up\n");
+        sResult = Result::Failed;
+        _pendingTop = false;
+        REG_DISPCAPCNT = 0;
+        gaveUp = true;
+    }
+
+    vu16* destination = (_screen == Screen::Top)
+        ? VRAM_A_LCDC + VRAM_A_CAPTURE_OFFSET / 2
+        : VRAM_C_LCDC;
+
+    if (!gaveUp)
+    {
+        // Same reason as the backup: the io thread reads these bytes with the cpu.
+        DC_InvalidateRange(_pixels, CAPTURE_BYTES);
+        dma_ntrCopy32(3, (const void*)destination, _pixels, CAPTURE_BYTES);
+    }
+    // Put back what was there while the block is still reachable through the
+    // LCDC window, then hand the hardware back.
+    dma_ntrCopy32(3, _blockBackup, (void*)destination, CAPTURE_BYTES);
+
+    if (_screen == Screen::Top)
+        RestoreMainEngine();
+    else
+        mem_setVramCMapping(_savedVramCMapping);
+
+    delete[] _blockBackup;
+    _blockBackup = nullptr;
+
+    if (gaveUp)
+    {
+        // Nothing was read, so there is nothing worth writing.
+        delete[] _pixels;
+        _pixels = nullptr;
+        // This returns before the line below that clears it, so it has to be
+        // cleared here too: left set, the next gesture's first half would be
+        // told it is somebody's second half.
+        _topIsSecondHalf = false;
+        _state = State::Idle;
+        return;
+    }
+
+    // Only the pointer crosses to the io thread, which owns it from here.
+    u16* pixels = _pixels;
+    bool topScreen = _screen == Screen::Top;
+    _pixels = nullptr;
+    _state = State::Idle;
+
+    // Read before the chaining below, which sets the flag for the capture that
+    // comes NEXT. Reading it after meant this capture took the flag meant for
+    // the other half, and the other half then ran without one - so the bottom
+    // asked to reuse a number nobody had claimed yet, and the top went looking
+    // for a fresh one.
+    bool secondHalf = _topIsSecondHalf;
+    _topIsSecondHalf = false;
+
+    if (_pendingTop)
+    {
+        _pendingTop = false;
+        _topIsSecondHalf = true;
+        _screen = Screen::Top;
+        _state = State::Requested;
+    }
+
+    sWritesQueued++;
+    _ioTaskQueue->Enqueue([pixels, topScreen, secondHalf] (const vu8& cancelRequested)
+    {
+        // The delete stays outside the cancel check: this lambda is the only
+        // owner of the pixels, so skipping it would leak 96 KB.
+        if (!cancelRequested)
+        {
+            // Sticky on failure until it is taken: one gesture writes two
+            // files, and a success arriving after a failure must not tell the
+            // player everything is saved when half of it is not.
+            bool ok = writeBmp(pixels, topScreen, secondHalf);
+            if (!ok || sResult != Screenshot::Result::Failed)
+                sResult = ok ? Screenshot::Result::Saved : Screenshot::Result::Failed;
+        }
+        delete[] pixels;
+        // Last, and outside the cancel check: the slot this task holds is given
+        // back either way, so the count has to move either way or the shortcut
+        // would refuse for the rest of the session.
+        sWritesDone++;
+        return TaskResult<void>::Completed();
+    });
+}
+
+bool Screenshot::IsWritePending()
+{
+    return sWritesQueued != sWritesDone;
+}
+
+void Screenshot::ReportBusy()
+{
+    if (sResult != Result::Failed)
+        sResult = Result::Busy;
+}
+
+Screenshot::Result Screenshot::TakeResult()
+{
+    // Held back until the whole gesture has finished writing, which is what
+    // makes the sticky failure above mean anything. One hold of the key writes
+    // two files, and this is polled every frame while a write takes many, so
+    // the first half's outcome was always collected before the second half had
+    // one: a pair whose top half failed said "screenshot saved" and then
+    // "couldn't save it", in that order, for the same shutter.
+    //
+    // Busy is not held. It answers a request that was refused *because* a write
+    // is in flight, so waiting for that write to end would be waiting to answer
+    // the one question whose answer is already known.
+    if (sResult != Result::Busy && IsWritePending())
+        return Result::None;
+
+    Result result = sResult;
+    sResult = Result::None;
+    return result;
+}

--- a/arm9/source/Screenshot.h
+++ b/arm9/source/Screenshot.h
@@ -1,0 +1,257 @@
+#pragma once
+#include <libtwl/mem/memVram.h>
+#include "core/task/TaskQueue.h"
+#include "gui/StackVramManager.h"
+
+/// @brief Saves a screen to /_pico/screenshots as a 24bpp BMP, using the
+///        display capture unit.
+///
+/// The capture unit belongs to the main engine and can only ever record what
+/// that engine draws, so the two screens are saved in two different ways.
+///
+/// The bottom screen is what the main engine already draws, so it is captured
+/// as it is. Block C is borrowed as the destination because it belongs to the
+/// sub engine and taking it away cannot disturb the frame being captured; its
+/// contents are copied out first and put back afterwards, since they are the top
+/// screen's background and nothing re-uploads them.
+///
+/// The top screen cannot be captured at all - the sub engine has no capture
+/// unit, and no register, mapping or screen swap can change that. What works
+/// instead is to make the main engine draw the top screen's picture for a single
+/// frame and capture that. Block C is the one block on the DS that either
+/// engine's backgrounds can read, and it is where this launcher keeps all of the
+/// top screen's background data, so the backgrounds need no copying at all: the
+/// same bytes mean the same thing to the other engine. Sprites and background
+/// palettes are not so lucky - their blocks have no main engine mapping in
+/// hardware - so those are copied, which is a few kilobytes.
+///
+/// The top screen loses its backgrounds for those frames, since the block
+/// holding them is what the capture writes into. The bottom screen used to show
+/// the same borrowed state; it is blacked out instead, so what the player sees
+/// is a flash. Then everything is put back.
+class Screenshot
+{
+public:
+    enum class Screen
+    {
+        Bottom,
+        Top,
+    };
+
+    /// The object vram managers are needed to find free space for the top
+    /// screen's sprite tiles: nothing already allocated may be overwritten.
+    Screenshot(TaskQueueBase* ioTaskQueue,
+        const StackVramManager* mainObjVram,
+        const StackVramManager* mainObjDialogVram,
+        const StackVramManager* subObjVram)
+        : _ioTaskQueue(ioTaskQueue)
+        , _mainObjVram(mainObjVram)
+        , _mainObjDialogVram(mainObjDialogVram)
+        , _subObjVram(subObjVram) { }
+
+    /// Nothing should be able to go away mid capture, but if it does the
+    /// borrowed blocks go back to the engine they came from.
+    ~Screenshot();
+
+    /// @brief Asks for both screens, as one request.
+    ///
+    /// The capture unit records one frame at a time, so the two are taken a
+    /// couple of frames apart and cannot be the same instant. They share a
+    /// number in their file names, which is what says they belong together.
+    void RequestBothScreens()
+    {
+        // Two doors to the same room, and only the first shows up in _state:
+        // the capture hardware is busy, or the io thread is still holding slots
+        // from the last gesture.
+        if (_state != State::Idle || IsWritePending())
+        {
+            ReportBusy();
+            return;
+        }
+        _screen = Screen::Bottom;
+        _state = State::Requested;
+        _pendingTop = true;
+        // Cleared here and not only where it is set, because it is a property
+        // of one gesture and the paths that abandon a gesture halfway do not
+        // all pass through the place that reads it.
+        _topIsSecondHalf = false;
+    }
+
+    /// @brief Whether a capture is in flight. Everything that draws through the
+    ///        engine being borrowed has to sit out those frames.
+    bool IsBusy() const { return _state != State::Idle; }
+
+    /// @brief Whether the main engine is being used to draw the top screen, so
+    ///        its own per frame work has to be left alone.
+    bool IsMirroringMainEngine() const
+    {
+        return _screen == Screen::Top && _state != State::Idle;
+    }
+
+    /// @brief Sets the capture up for the coming frame. Call from the VBlank
+    ///        handler: for the bottom screen as the first thing, so the sprites
+    ///        uploaded just after are the ones recorded, and the mirroring for
+    ///        the top screen needs the sub sprites already uploaded, so this is
+    ///        called at the end too.
+    void VBlankBegin();
+
+    /// @brief Hands the sub engine's memory, palettes and objects to the main
+    ///        engine when a top screen capture is pending. Returns true when it
+    ///        did, which means the views owning write only registers have to
+    ///        write theirs to the main engine before ArmMirroredCapture.
+    bool MirrorSubEngineIfPending();
+
+    /// @brief Points the main engine at the mirrored setup and starts the
+    ///        capture. Call after the views have had their say.
+    void ArmMirroredCapture();
+
+    /// @brief Reads the captured frame back and puts the hardware right again.
+    ///        Call from the visible period (Update): the copies are far too long
+    ///        for the VBlank budget.
+    void Update();
+
+    /// @brief How the last finished capture ended.
+    enum class Result
+    {
+        None,
+        Saved,
+        Failed,
+        /// Asked for while the previous one was still being written. Its own
+        /// answer because it is not a failure and telling the player nothing
+        /// is indistinguishable from the shortcut being broken.
+        Busy
+    };
+
+    /// @brief Returns the outcome of the last capture that finished writing and
+    ///        forgets it, so a caller polling it is told once.
+    ///
+    /// The io thread is what finishes a capture, so this turns up a few frames
+    /// after the shutter rather than with it. That delay is why a confirmation
+    /// shown on this cannot land inside the picture it is confirming. It says
+    /// nothing about the next one: a message still on screen when the player
+    /// asks for another shot is part of that shot, the same as anything else
+    /// they can see.
+    static Result TakeResult();
+
+private:
+    /// The display registers the mirror copies over and puts back - only the
+    /// ones that can be READ. Scroll, the affine matrices, the window
+    /// rectangles, mosaic and blend fade read back as zero on both engines, so
+    /// copying those would mirror nothing and silently drop the cover art. They
+    /// are written by value instead.
+    ///
+    /// Here rather than beside the loops that walk it so that the array it
+    /// sizes cannot drift from it. It was a hardcoded count in this header and
+    /// a separate table in the cpp, with nothing tying the two together: adding
+    /// a register would have written one past the end of the save area, and the
+    /// compiler only catches that because the loop bound is a constant it can
+    /// see through.
+    ///
+    /// Master brightness is not in this list even though it can be read. The
+    /// blackout it carries has to be the last thing lifted, so it is saved and
+    /// put back on its own - see RestoreMainEngine.
+    static constexpr u16 kMirroredRegs[] =
+    {
+        0x08, 0x0A, 0x0C, 0x0E, // BG0-3 control
+        0x48, 0x4A,             // window contents
+        0x50, 0x52,             // blend control and alpha
+    };
+    static constexpr u32 kMirroredRegCount =
+        sizeof(kMirroredRegs) / sizeof(kMirroredRegs[0]);
+    /// How many visible periods to wait for the capture before giving up. The
+    /// hardware clears the enable bit at the end of the frame it records, so the
+    /// bit is normally already clear on the first look and none of this budget is
+    /// spent; the allowance is only here so a dropped frame does not throw a good
+    /// capture away.
+    static constexpr u32 kCaptureWaitFrames = 8;
+
+    /// @brief Reports that a request arrived while a capture was in flight.
+    static void ReportBusy();
+
+    /// @brief Whether a file from an earlier capture is still queued on the io
+    ///        thread.
+    ///
+    /// This exists because `_state` cannot answer it. `_state` returns to Idle
+    /// as soon as the pixels are out of vram, frames before the file reaches the
+    /// card, and it has to: `IsBusy()` is what stops the top screen from
+    /// uploading covers, and holding that for the length of a write would freeze
+    /// the cover for about a second per shot.
+    ///
+    /// So the bound lives here instead. A gesture is accepted only when nothing
+    /// of ours is outstanding, and one gesture queues exactly two tasks, which
+    /// makes "this class never holds more than two of the shared io slots" a
+    /// property of the code rather than of how much heap happens to be free.
+    /// That margin is thinner than it looks: the icon grid alone asks for 28 of
+    /// the 32 slots in a single frame.
+    ///
+    /// It is a latch, not a timeout. A task that is queued and never runs -
+    /// only reachable by enqueueing after the io thread has been stopped -
+    /// leaves the shortcut refusing for the rest of the session. There is
+    /// deliberately no recovery: resetting the count on a timer would hand one
+    /// slot's accounting to two owners.
+    static bool IsWritePending();
+
+    enum class State
+    {
+        Idle,
+        /// Asked for; buffers still to be taken and contents still to be saved.
+        Requested,
+        /// Saved, waiting for the VBlank that sets the hardware up.
+        Arming,
+        /// The hardware is writing the frame into the destination block.
+        Capturing,
+    };
+
+    TaskQueueBase* _ioTaskQueue;
+    const StackVramManager* _mainObjVram;
+    const StackVramManager* _mainObjDialogVram;
+    const StackVramManager* _subObjVram;
+    State _state = State::Idle;
+    /// Set by RequestBothScreens: the top screen follows once the bottom one is
+    /// handed to the io thread. Cleared on every path that gives up, so a
+    /// failure does not drag a second one behind it.
+    bool _pendingTop = false;
+    /// Marks the top capture as the second half of a pair, so its file is given
+    /// the number the bottom half already claimed instead of a fresh one.
+    bool _topIsSecondHalf = false;
+    Screen _screen = Screen::Bottom;
+
+    /// What was in the block the capture writes into, and the captured frame.
+    /// Both are owned here until the write task takes the pixels.
+    u16* _blockBackup = nullptr;
+    u16* _pixels = nullptr;
+
+    // Everything the top screen capture has to put back.
+    MemVramABMapping _savedVramAMapping = MEM_VRAM_AB_LCDC;
+    MemVramCMapping _savedVramCMapping = MEM_VRAM_C_LCDC;
+    MemVramFGMapping _savedVramFMapping = MEM_VRAM_FG_LCDC;
+    MemVramFGMapping _savedVramGMapping = MEM_VRAM_FG_LCDC;
+    MemVramHMapping _savedVramHMapping = MEM_VRAM_H_LCDC;
+    u32 _savedDispCnt = 0;
+    /// Kept apart from _savedRegs because the blackout is lifted last.
+    u16 _savedMasterBright = 0;
+    u16 _savedRegs[kMirroredRegCount] = { };
+    u16 _savedBgPltt[256] = { };
+    u16 _savedObjPltt[256] = { };
+    /// The extended palette copies land on blocks F and G, which are the main
+    /// engine's background tiles - and the bottom sheet's tiles live there in
+    /// the only copy there is, so what is written over has to come back.
+    ///
+    /// Cache line aligned because these two are the only members filled by dma,
+    /// so they are the only ones the cache has to be dropped for first. An
+    /// unaligned invalidate throws away the lines at both ends of the range as
+    /// well, and the neighbours here are the tail of _savedObjPltt and the two
+    /// members below - losing a dirty line there would restore the wrong object
+    /// palette, hide the sprites, or leave the vcount irq masked for the rest of
+    /// the session. Their size is already a whole number of lines.
+    alignas(32) u16 _savedFBytes[256] = { };
+    alignas(32) u16 _savedGBytes[256] = { };
+    u32 _spriteTileOffset = 0;
+    bool _vcountIrqSuppressed = false;
+    /// Visible periods spent waiting for the hardware to clear the enable bit.
+    u32 _captureWaitFrames = 0;
+
+    void PrepareTopCapture();
+    void MirrorSubEngine();
+    void RestoreMainEngine();
+};

--- a/arm9/source/gui/views/Label3DView.cpp
+++ b/arm9/source/gui/views/Label3DView.cpp
@@ -30,6 +30,10 @@ void Label3DView::UpdateTileBuffer()
 {
     _vblankTextureLoader->CancelLoad(_textureLoadRequest);
     LabelView::UpdateTileBuffer();
+    // The 2d label promotes this when its sprites go up; nothing promoted it
+    // here, so GetStringWidth() read zero forever on a 3d label. The texture
+    // lands one frame later than the number, which no caller can tell apart.
+    _stringWidth = _newStringWidth;
     _textureLoadRequest = VBlankTextureLoadRequest(_tileBuffer.get(), _tileBufferSize,
         _texVramOffset, nullptr, 0, 0, nullptr, nullptr);
     _vblankTextureLoader->RequestLoad(_textureLoadRequest);
@@ -42,22 +46,22 @@ void Label3DView::Draw(GraphicsContext& graphicsContext)
 
     Gx::MtxIdentity();
     Gx::PolygonAttr(GX_LIGHTMASK_NONE, GX_POLYGON_MODE_MODULATE, GX_DISPLAY_MODE_FRONT,
-        false, false, false, GX_DEPTH_FUNC_LESS, false, 31, graphicsContext.GetPolygonId());
+        false, false, false, GX_DEPTH_FUNC_LESS, false, _alpha, graphicsContext.GetPolygonId());
     Gx::TexImageParam(_texVramOffset >> 3, false, false, false, false, (GxTexSize)(std::bit_width(_actualWidth) - 4),
         GX_TEXSIZE_1024, GX_TEXFMT_A5I3, false, GX_TEXGEN_NONE);
     graphicsContext.GetRgb6Palette()->ApplyColor(Rgb<6, 6, 6>(_foregroundColor));
     Gx::Begin(GX_PRIMITIVE_QUAD);
     Gx::TexCoord(0, 0);
     REG_GX_VTX_16 = GX_VTX_PACK(_position.x << 6, _position.y << 3);
-    REG_GX_VTX_16 = (200) << 6;
+    REG_GX_VTX_16 = _depth << 6;
     Gx::TexCoord(0, (int)_height);
     REG_GX_VTX_16 = GX_VTX_PACK(_position.x << 6, (_position.y + _height) << 3);
-    REG_GX_VTX_16 = (200) << 6;
+    REG_GX_VTX_16 = _depth << 6;
     Gx::TexCoord((int)_width, (int)_height);
     REG_GX_VTX_16 = GX_VTX_PACK((_position.x + _width) << 6, (_position.y + _height) << 3);
-    REG_GX_VTX_16 = (200) << 6;
+    REG_GX_VTX_16 = _depth << 6;
     Gx::TexCoord((int)_width, 0);
     REG_GX_VTX_16 = GX_VTX_PACK((_position.x + _width) << 6, _position.y << 3);
-    REG_GX_VTX_16 = (200) << 6;
+    REG_GX_VTX_16 = _depth << 6;
     Gx::End();
 }

--- a/arm9/source/gui/views/Label3DView.h
+++ b/arm9/source/gui/views/Label3DView.h
@@ -12,6 +12,14 @@ public:
     void InitVram(const VramContext& vramContext) override;
     void Draw(GraphicsContext& graphicsContext) override;
 
+    /// @brief Sets the depth the text quad is drawn at. Smaller is nearer, and
+    ///        negative is allowed: it puts the text in front of everything the
+    ///        launcher draws at zero.
+    void SetDepth(int depth) { _depth = depth; }
+
+    /// @brief Sets the polygon alpha, 0 to 31, so a caller can fade the text.
+    void SetAlpha(u32 alpha) { _alpha = alpha; }
+
 private:
     Label3DView(u32 width, u32 height, u32 maxStringLength, const nft2_header_t* font,
         VBlankTextureLoader* vblankTextureLoader);
@@ -19,6 +27,8 @@ private:
     void UpdateTileBuffer() override;
 
     u32 _texVramOffset = 0;
+    int _depth = 200;
+    u32 _alpha = 31;
     VBlankTextureLoader* _vblankTextureLoader;
     VBlankTextureLoadRequest _textureLoadRequest;
 };

--- a/arm9/source/gui/views/ToastView.cpp
+++ b/arm9/source/gui/views/ToastView.cpp
@@ -1,0 +1,284 @@
+#include "common.h"
+#include <algorithm>
+#include "gui/Gx.h"
+#include "gui/GraphicsContext.h"
+#include "gui/VramContext.h"
+#include <libtwl/gfx/gfxWindow.h>
+#include <libtwl/gfx/gfx.h>
+#include "gui/materialDesign.h"
+#include "themes/FontType.h"
+#include "ToastView.h"
+
+// Low on the screen, clear of the carousel covers that run from y 56 to y 152,
+// and clear of the app bar, which every layout puts at the top or down the left
+// side. Being in front is handled by depth rather than by hiding here, so this is
+// a placement choice and moving it is one number.
+#define TOAST_BOTTOM        180
+#define TOAST_HEIGHT        22
+
+// Room to breathe on both sides of the text. The panel is sized to the string
+// rather than to the screen, so a two word confirmation reads as something the
+// launcher put there on purpose instead of a bar across the bottom.
+#define TEXT_PADDING_X      14
+#define MIN_WIDTH           72
+#define MAX_WIDTH           232
+
+#define TEXT_HEIGHT         12
+#define TEXT_WIDTH          (MAX_WIDTH - 2 * TEXT_PADDING_X)
+
+// The label rounds its texture up to the next power of two, so asking for more
+// than 256 pixels of width would double the vram it holds for the session.
+#define MAX_STRING_LENGTH   48
+
+// One pixel off each corner, and no more than one.
+//
+// The window that hides the sprites underneath can only be a rectangle, so
+// every pixel of that rectangle the panel does not fill shows the bare page
+// instead - no icons, no panel. Measured on a real capture with a radius of
+// four: the corners came out as the page colour, which against a game icon
+// reads as four white notches, and on a themed background would be whatever
+// that theme happens to have there. That is a shape mismatch, not a colour
+// problem, so the fix is to stop mismatching.
+//
+// At one pixel the panel is a rectangle with its corners shaved: enough to not
+// read as a hard box, and small enough that what shows through cannot be seen
+// on any theme. Rounding it properly needs the window to have the same shape as
+// the panel, which means an object window and a mask sprite - worth doing if
+// this ever wants to be a real pill, and not worth it for four pixels.
+#define CORNER_ROWS         1
+static const u8 kCornerInset[CORNER_ROWS] = { 1 };
+
+// Material calls this pattern a snackbar and gives its short form four seconds.
+// Two is enough here: the user caused the thing being confirmed, so they are
+// already looking, and it sits over the list they are using.
+#define HOLD_FRAMES         120
+#define FADE_IN_FRAMES      md::sys::motion::duration::medium2
+#define FADE_OUT_FRAMES     md::sys::motion::duration::short4
+
+// How far it starts below where it settles. Small on purpose: this should read
+// as the panel arriving, not as something sliding across the screen.
+#define RISE_PIXELS         4
+
+// The text has to be nearer than the panel it sits on, and the panel nearer than
+// anything it covers. Nearer than everything, in fact: the custom themes draw
+// their icon grid items at minus five, so a confirmation sitting at zero would be
+// hidden behind the grid on those themes. Just past that rather than far past it,
+// because a vertex in front of the near plane is clipped away entirely.
+#define BACKGROUND_DEPTH    (-6)
+#define TEXT_DEPTH          (-7)
+
+#define MAX_ALPHA           31
+#define PROGRESS_MAX        256
+
+// Two ids, because translucent polygons that share one do not blend with each
+// other: on a single id the text would punch a hole through the panel while both
+// are fading. And not 62 or 63, which look free and are not - the icon button
+// selector draws with 62 and the custom app bar scrim with 63, so a shared id
+// with either would drop the overlap instead of blending it. Everything from 1
+// to 61 is unused.
+#define BACKGROUND_POLYGON_ID   60
+#define TEXT_POLYGON_ID         61
+
+ToastView::ToastView(const MaterialColorScheme* materialColorScheme,
+    const IFontRepository* fontRepository, VBlankTextureLoader* vblankTextureLoader)
+    : _materialColorScheme(materialColorScheme)
+    , _label(Label3DView::CreateShared(TEXT_WIDTH, TEXT_HEIGHT, MAX_STRING_LENGTH,
+        fontRepository->GetFont(FontType::Medium10), vblankTextureLoader))
+    , _progressAnimator(0)
+{
+    _label->SetDepth(TEXT_DEPTH);
+    _label->SetEllipsisStyle(LabelView::EllipsisStyle::Ellipsis);
+}
+
+void ToastView::InitVram(const VramContext& vramContext)
+{
+    _label->InitVram(vramContext);
+}
+
+void ToastView::Show(const char* text)
+{
+    _label->SetText(text);
+
+    // Sized to the string now that there is one, and centred on the screen.
+    u32 textWidth = _label->GetStringWidth();
+    _width = std::clamp(textWidth + 2 * TEXT_PADDING_X, (u32)MIN_WIDTH, (u32)MAX_WIDTH);
+    _x = (256 - (int)_width) / 2;
+
+    // Restarting from whatever is on screen rather than from nothing, so a second
+    // message replacing a first one does not blink.
+    _state = State::FadingIn;
+    _holdFrames = 0;
+    _progressAnimator.Goto(PROGRESS_MAX, FADE_IN_FRAMES, &md::sys::motion::easing::emphasizedDecelerate);
+}
+
+void ToastView::Update()
+{
+    if (_state == State::Hidden)
+        return;
+
+    switch (_state)
+    {
+        case State::FadingIn:
+        {
+            if (_progressAnimator.Update())
+                _state = State::Holding;
+            break;
+        }
+
+        case State::Holding:
+        {
+            if (++_holdFrames >= HOLD_FRAMES)
+            {
+                _state = State::FadingOut;
+                _progressAnimator.Goto(0, FADE_OUT_FRAMES, &md::sys::motion::easing::emphasizedAccelerate);
+            }
+            break;
+        }
+
+        case State::FadingOut:
+        {
+            if (_progressAnimator.Update())
+                _state = State::Hidden;
+            break;
+        }
+
+        case State::Hidden:
+            break;
+    }
+
+    int progress = _progressAnimator.GetValue();
+    _alpha = (u32)(progress * MAX_ALPHA / PROGRESS_MAX);
+    // Rises into place as it appears, and sinks back as it goes.
+    _y = TOAST_BOTTOM - TOAST_HEIGHT + RISE_PIXELS - progress * RISE_PIXELS / PROGRESS_MAX;
+
+    _label->SetAlpha(_alpha);
+    _label->SetPosition(_x + TEXT_PADDING_X, _y + (TOAST_HEIGHT - TEXT_HEIGHT) / 2);
+    _label->Update();
+}
+
+Rectangle ToastView::GetBounds() const
+{
+    return Rectangle(_x, _y, (int)_width, TOAST_HEIGHT);
+}
+
+// Bit per layer in the window contents registers: backgrounds 0 to 3, then
+// objects, then the colour special effects.
+#define WINDOW_ALL_BGS      0x0F
+#define WINDOW_OBJ          0x10
+#define WINDOW_EFFECTS      0x20
+#define WINDOW_EVERYTHING   (WINDOW_ALL_BGS | WINDOW_OBJ | WINDOW_EFFECTS)
+#define DISPCNT_WINDOW_1    (1 << 14)
+
+// Backgrounds 1 and 2, which the bottom sheet owns: the sheet's panel is
+// background 1 at priority 1 and its scrim is background 2 at priority 2, while
+// this is drawn on the 3d layer, which is background 0 at priority 3. Both of
+// them therefore beat it, and switching the objects off does nothing about a
+// background - so with a sheet open the message was drawn underneath it and the
+// user was told nothing at all.
+//
+// A window can only switch a layer off, so the sheet is switched off inside this
+// rectangle rather than the message being lifted above it. While the message is
+// fading its panel is not yet opaque, so for those frames the rectangle shows
+// the page behind the sheet instead of the sheet. That is the price of the only
+// mechanism the hardware offers here, and it buys a confirmation that is
+// actually visible.
+#define WINDOW_SHEET_BGS    0x06
+
+void ToastView::ApplyWindow()
+{
+    gfx_setWindow1((u8)_x, (u8)_y, (u8)(_x + (int)_width), (u8)(_y + TOAST_HEIGHT));
+
+    // Only the top half of this register belongs to window 1; window 0 is the
+    // screenshot's, so its half is left exactly as it was.
+    REG_WININ = (u16)((REG_WININ & 0x00FF) |
+        (((WINDOW_ALL_BGS & ~WINDOW_SHEET_BGS) | WINDOW_EFFECTS) << 8));
+
+    // Enabling any window makes the whole screen outside it obey this, so it has
+    // to say everything, or turning the toast on would change the rest of the
+    // screen. The object window half is left alone.
+    REG_WINOUT = (u16)((REG_WINOUT & 0xFF00) | WINDOW_EVERYTHING);
+
+    REG_DISPCNT |= DISPCNT_WINDOW_1;
+}
+
+void ToastView::DisableWindow()
+{
+    // Unconditional, not guarded by a flag of our own. A screenshot of the top
+    // screen saves and restores the whole display control register, so if the
+    // toast happens to end during those frames the window comes back enabled
+    // with a stale rectangle. A flag would then think it had already been
+    // switched off and leave a patch of hidden sprites on screen for good.
+    REG_DISPCNT &= ~DISPCNT_WINDOW_1;
+}
+
+void ToastView::VBlank()
+{
+    // Unconditional both ways, and no flag of our own to remember what the
+    // hardware was last told: a top screen capture saves and restores the whole
+    // display control register, so a window this class thought it had already
+    // switched off can come back enabled with a stale rectangle.
+    if (_wantWindow)
+        ApplyWindow();
+    else
+        DisableWindow();
+}
+
+void ToastView::DrawRow(int y, int height, int inset, int depth) const
+{
+    int left = _x + inset;
+    int right = _x + (int)_width - inset;
+    REG_GX_VTX_16 = GX_VTX_PACK(left << 6, y << 3);
+    REG_GX_VTX_16 = depth << 6;
+    REG_GX_VTX_16 = GX_VTX_PACK(left << 6, (y + height) << 3);
+    REG_GX_VTX_16 = depth << 6;
+    REG_GX_VTX_16 = GX_VTX_PACK(right << 6, (y + height) << 3);
+    REG_GX_VTX_16 = depth << 6;
+    REG_GX_VTX_16 = GX_VTX_PACK(right << 6, y << 3);
+    REG_GX_VTX_16 = depth << 6;
+}
+
+void ToastView::Draw(GraphicsContext& graphicsContext)
+{
+    // The window has to follow exactly what gets drawn, so the decision is
+    // made here, next to the drawing, and carried out in VBlank so that it
+    // lands on the same frame the panel does. Deciding it anywhere else went
+    // wrong twice: from Update it wrote the registers of an engine a capture
+    // had already borrowed, and on the frame a fade finished it enabled the
+    // window while Draw bailed out on zero alpha, leaving a hole with nothing
+    // drawn over it.
+    if (_state == State::Hidden || _alpha == 0 || !graphicsContext.IsVisible(GetBounds()))
+    {
+        _wantWindow = false;
+        return;
+    }
+
+    _wantWindow = true;
+
+    // No texture at all, so the panel costs nothing in vram and does not depend
+    // on a texel that only one theme happens to keep around. With texturing off
+    // in modulate mode, the vertex colour is what gets drawn.
+    //
+    // The colours are the pair the launcher already dresses its own cards in,
+    // taken from the active theme, so this belongs to the page rather than
+    // sitting on top of it. Material would invert a snackbar to its darkest
+    // surface, which here would read as a foreign element.
+    Gx::MtxIdentity();
+    Gx::PolygonAttr(GX_LIGHTMASK_NONE, GX_POLYGON_MODE_MODULATE, GX_DISPLAY_MODE_FRONT,
+        false, false, false, GX_DEPTH_FUNC_LESS, false, _alpha, BACKGROUND_POLYGON_ID);
+    Gx::TexImageParam(0, false, false, false, false, GX_TEXSIZE_8, GX_TEXSIZE_8,
+        GX_TEXFMT_NONE, false, GX_TEXGEN_NONE);
+    Gx::Color(Rgb<5, 5, 5>(_materialColorScheme->secondaryContainer));
+
+    Gx::Begin(GX_PRIMITIVE_QUAD);
+    for (int i = 0; i < CORNER_ROWS; i++)
+        DrawRow(_y + i, 1, kCornerInset[i], BACKGROUND_DEPTH);
+    DrawRow(_y + CORNER_ROWS, TOAST_HEIGHT - 2 * CORNER_ROWS, 0, BACKGROUND_DEPTH);
+    for (int i = 0; i < CORNER_ROWS; i++)
+        DrawRow(_y + TOAST_HEIGHT - 1 - i, 1, kCornerInset[i], BACKGROUND_DEPTH);
+    Gx::End();
+
+    _label->SetForegroundColor(_materialColorScheme->onSecondaryContainer);
+    u32 oldPolygonId = graphicsContext.SetPolygonId(TEXT_POLYGON_ID);
+    _label->Draw(graphicsContext);
+    graphicsContext.SetPolygonId(oldPolygonId);
+}

--- a/arm9/source/gui/views/ToastView.h
+++ b/arm9/source/gui/views/ToastView.h
@@ -1,0 +1,108 @@
+#pragma once
+#include "common.h"
+#include "animation/Animator.h"
+#include "core/SharedPtr.h"
+#include "gui/views/Label3DView.h"
+#include "gui/views/View.h"
+#include "themes/IFontRepository.h"
+#include "themes/material/MaterialColorScheme.h"
+
+class VBlankTextureLoader;
+
+/// @brief A short message that confirms something happened and then goes away
+///        on its own.
+///
+/// The only other way the launcher speaks to the user is the bottom sheet, which
+/// is modal: it waits for an answer. This one asks for nothing. It never takes
+/// focus, never takes input, and leaves whether it was read or not, so it suits
+/// the things that need saying but not answering - a screenshot written, a jump
+/// that landed on a letter, a save that failed.
+///
+/// It is dressed in the colours the active theme gives its cards and it is sized
+/// to its own text, so it reads as part of the page rather than as a panel laid
+/// over it. It draws on the bottom screen, the one the user is looking at and the
+/// one the launcher fully owns.
+class alignas(32) ToastView : public View
+{
+    SHARED_ONLY(ToastView)
+
+public:
+    /// @brief Shows the given message, restarting the timer if one is already up.
+    ///
+    /// Only one message exists at a time and the newest wins. A queue would make
+    /// the user wait to be told about the thing they just did, and the older
+    /// message is the one they care about least.
+    void Show(const char* text);
+
+    void InitVram(const VramContext& vramContext) override;
+    void Update() override;
+    void Draw(GraphicsContext& graphicsContext) override;
+    void VBlank() override;
+    Rectangle GetBounds() const override;
+
+private:
+    enum class State
+    {
+        Hidden,
+        FadingIn,
+        Holding,
+        FadingOut
+    };
+
+    ToastView(const MaterialColorScheme* materialColorScheme,
+        const IFontRepository* fontRepository, VBlankTextureLoader* vblankTextureLoader);
+
+    /// @brief Draws one horizontal band of the panel, inset from both edges by
+    ///        the same amount. Stacking bands is what rounds the corners.
+    void DrawRow(int y, int height, int inset, int depth) const;
+
+    /// @brief Hides the sprites behind the panel, and puts them back.
+    ///
+    /// The 3d layer this is drawn on is background 0, which the launcher gives
+    /// the lowest priority there is, and a sprite beats a background of equal
+    /// priority. So in any layout that fills the screen with sprites - the icon
+    /// grid does - the panel would sit behind them. Window 1 of the main engine
+    /// is unused, and a window can switch objects off inside its rectangle,
+    /// which is the only way to be in front of them without rebuilding this as
+    /// a background layer of its own.
+    ///
+    /// Decided in Draw and applied in VBlank, because the panel is geometry:
+    /// what Draw submits only reaches the screen after the buffer swap, while a
+    /// register write lands on the frame being scanned right now. Writing the
+    /// window from Draw therefore opened it a frame EARLY - the first frame of
+    /// a message switched the sprites off with nothing drawn over them yet -
+    /// and closed it a frame early too, putting them back while the last panel
+    /// was still on screen. The class exists to avoid exactly that rectangle of
+    /// hidden sprites with nothing on top; it was guarding one edge of it.
+    ///
+    /// Not from Update either: that runs in the visible period, when a capture
+    /// of the top screen may already have borrowed this engine.
+    void ApplyWindow();
+    void DisableWindow();
+
+public:
+    /// @brief Asks for the window to be closed, for the frames a caller has to
+    ///        keep this off the screen.
+    ///
+    /// Skipping Draw is not enough on its own: the window would stay open with
+    /// the last rectangle and nothing painted inside it, which is the hole this
+    /// class exists to avoid. This says so instead, and the next VBlank acts on
+    /// it - which is also why it writes no register: the callers that need this
+    /// are the ones whose frames the engine has been lent out on.
+    void Suppress() { _wantWindow = false; }
+
+private:
+
+    const MaterialColorScheme* _materialColorScheme;
+    SharedPtr<Label3DView> _label;
+    State _state = State::Hidden;
+    u32 _holdFrames = 0;
+    /// Drives the fade and the rise together, so they cannot come apart.
+    Animator<int> _progressAnimator;
+    int _x = 0;
+    int _y = 0;
+    u32 _width = 0;
+    u32 _alpha = 0;
+    /// What Draw decided the window should be doing, for VBlank to carry out.
+    bool _wantWindow = false;
+};

--- a/arm9/source/romBrowser/views/RomBrowserTopScreenView.cpp
+++ b/arm9/source/romBrowser/views/RomBrowserTopScreenView.cpp
@@ -92,6 +92,29 @@ void RomBrowserTopScreenView::Update()
     ViewContainer::Update();
 }
 
+void RomBrowserTopScreenView::MirrorToMainEngine() const
+{
+    // Same numbers as VBlank puts on the sub engine, aimed at the main one.
+    int x0 = std::clamp(_coverPosition.x, 0, 256);
+    int x1 = std::clamp(_coverPosition.x + 106, 0, 256);
+    int y0 = std::clamp(_coverPosition.y, 0, 192);
+    int y1 = std::clamp(_coverPosition.y + 96, 0, 192);
+    if (!_showCover || !_selectedFileCover.IsValid() || !_selectedFileCover->IsActualCover() ||
+        x0 >= x1 || y0 >= y1)
+    {
+        // No cover on screen, so nothing to restate: the mirrored display
+        // control already has this background and its window switched off.
+        return;
+    }
+    REG_BG3PA = 0x100;
+    REG_BG3PB = 0;
+    REG_BG3PC = 0;
+    REG_BG3PD = -0x100;
+    REG_BG3X = (-_coverPosition.x) << 8;
+    REG_BG3Y = (96 + _coverPosition.y - 1) << 8;
+    gfx_setWindow0(x0, y0, x1, y1);
+}
+
 void RomBrowserTopScreenView::VBlank()
 {
     ViewContainer::VBlank();

--- a/arm9/source/romBrowser/views/RomBrowserTopScreenView.h
+++ b/arm9/source/romBrowser/views/RomBrowserTopScreenView.h
@@ -18,6 +18,13 @@ public:
     void Update() override;
     void VBlank() override;
 
+    /// @brief Writes the cover's affine matrix and clip window to the MAIN
+    ///        engine, for the one frame a screenshot borrows that engine to draw
+    ///        this screen. Those registers cannot be read back, so they cannot
+    ///        be copied across - only the view that computes them can restate
+    ///        them.
+    void MirrorToMainEngine() const;
+
     Rectangle GetBounds() const override
     {
         return Rectangle(0, 0, 256, 192);

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -13,6 +13,7 @@ From here you can browse your SD card to launch homebrew and games.
 - B: Go to the parent folder or close a menu.
 - L and R: Scroll quickly when there are many items in a folder.
 - Y: Open the cheats panel (see [Cheats](Cheats.md)).
+- START (hold): Save a screenshot of both screens (see [Screenshots](#screenshots)).
 
 The back arrow on the top left of the bottom screen can also be used to go up to the parent folder.
 
@@ -39,6 +40,19 @@ Currently, the only settings available are the display mode, and the sorting mod
         <td><img src="./images/Coverflow.png"/></td>
     </tr>
 </table>
+
+## Screenshots
+Holding START for about half a second saves both screens to `/_pico/screenshots` on your SD card, as BMP files.
+
+Each hold writes two files that share a number: `shotNNN_bot.bmp` for the bottom screen and `shotNNN_top.bmp` for the top one. The number is the lowest one neither screen has taken yet, so a pair is always the two halves of one press. Up to 1000 pairs fit in the folder.
+
+A short message appears at the bottom of the screen once the files are on the card. It confirms the write rather than the button press, so if something goes wrong - a full folder, or a card that cannot be written to - it says that instead.
+
+A few things worth knowing:
+- The two screens are recorded a couple of frames apart. The console can only capture one screen at a time, so during a fast animation the two halves of a pair will not match exactly.
+- The screen flashes while the picture is taken. That is the capture, not a fault.
+- The shortcut works in the file browser and in the settings menu. It does not work in the theme selector, which is a separate screen with its own input handling.
+- The hold has to begin while Pico Launcher is running, so a button that was already held down when it started is not read as a request.
 
 ## Settings
 Settings are stored on your SD card in `/_pico/settings.json`. They can be edited with any text editor. The following settings are available:


### PR DESCRIPTION
This is the launcher side of #27. Hold START for about half a second and both screens are saved to `/_pico/screenshots`, as `shotNNN_bot.bmp` and `shotNNN_top.bmp` sharing a number so a pair is the two halves of one press. In game captures, which is what the issue was opened for, are LNH-team/pico-loader#151 and not in here.

<img width="512" height="780" alt="1-material-grid-toast" src="https://github.com/user-attachments/assets/486a7031-954b-4cd7-8d2c-7612e8483509" />

The top screen is the part I did not expect to get, and it is the one the request asks for by name. There is one capture register and it belongs to the main engine, and the sub engine has no vram display mode to route its output through, so for a while I thought it could not be done. It can, by making the main engine draw the top screen for one frame and capturing that. Here the backgrounds come for free: block C already holds them and the main engine reads the same bytes at the same offsets, so nothing is copied for those. The sprite tiles and both palettes are copied, plus the two background extended palette slots in use, because those blocks have no main engine mapping. A few kilobytes. The write only registers are set by value, since reading them back gives zeros and the cover art would just disappear from the picture.

I wrote the rest up in #27 in August. What has changed since: the bottom screen no longer shows borrowed state while the capture holds the engine, it is blacked out instead, so what you see is a flash. Master brightness is applied after the capture unit, so the saved image is unaffected. The top screen still loses its backgrounds for those frames.

START, and only START. SELECT is not usable on its own on DSi, where the brightness is SELECT plus the volume buttons and the volume buttons are not readable in DS mode, so someone turning the brightness down would look exactly like someone asking for a screenshot. That part is from Nintendo's own documentation, not from testing - nobody here has a DSi.

The one screen it does not reach is the theme selector, which is a separate process with its own input handling.

The confirmation message is a new UI primitive, `ToastView`, and about a quarter of this diff. There was nothing transient to say "saved" with, only the modal bottom sheet. It appears once the files are on the card rather than when the button goes down, so it cannot land inside the shot it is confirming - though a message still up when you ask for the next one is part of that shot, as in the screenshot above. A new primitive is your call rather than mine: say so and I will split it out.

<img width="512" height="780" alt="2-custom-theme-coverflow" src="https://github.com/user-attachments/assets/1f7330da-6bc3-4d71-ad66-5e0b2f7fdedc" />

One thing I cannot explain, and would rather say than have you find. On some builds of this branch a one pixel line appears on the top screen during the splash, and on others it does not, with no relation to what the commit in between changed. The capture code does nothing during the splash, so I doubt it is this, but I have not proved where it comes from. It does not appear on the recent builds.

Tested on a DS Lite and a New 3DS across the branch: every layout, light and dark and a custom theme, and with a bottom sheet open. Every file 147510 bytes, pairs contiguous, no orphans. Four commits, each one building on its own.