### PR TITLE
Fix races between banner list rows and their background load tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support for custom folder covers via a cover.bmp file placed inside the folder - by @tasken
 
 ### Fixed
+- Banner list rows no longer race with their background load task, which could write a title into a row that had already been recycled
 - Top screen cover is now displayed/hidden correctly when placed partially or fully off-screen
 - DSi banners with missing DSi part now fall back to the DS icon
 - Game-code cover lookup no longer searches on a stale buffer when a file has no game code

--- a/arm9/source/core/task/TaskQueue.h
+++ b/arm9/source/core/task/TaskQueue.h
@@ -28,6 +28,11 @@ public:
         if (_task)
         {
             _task->RequestCancel();
+            // RequestCancel() only sets a flag - a task that is already Running on the
+            // IO thread keeps executing until its next cancellation check. Block here
+            // until it actually reaches Canceled/Completed before we let the caller
+            // treat whatever it was touching (a view, a FileInfoManager slot) as free.
+            _task->Wait();
             Dispose();
         }
     }

--- a/arm9/source/gui/views/LabelView.cpp
+++ b/arm9/source/gui/views/LabelView.cpp
@@ -103,6 +103,21 @@ void LabelView::UpdateTileBuffer()
     {
         _newStringWidth = 0;
     }
+
+    // The buffer now reflects the current ellipsis style, so there is no more
+    // pending work for Update() to do. Clearing this here (rather than only in
+    // Update(), after the fact) matters because SetEllipsisStyle()+SetText()/
+    // SetTextAsync() are called back-to-back from the banner list's background
+    // IO task while binding a row. If we left the flag set, the next frame's
+    // Update() (main thread) would redundantly call UpdateTileBuffer() again on
+    // this same LabelView - and by then the row may already have been recycled
+    // and be mid-bind for a *different* item on the IO thread, so the two
+    // unsynchronized UpdateTileBuffer() calls race on the same _textBuffer/
+    // _tileBuffer, producing blank or wrong-looking list rows. Every caller of
+    // SetEllipsisStyle() in this codebase immediately follows it with a
+    // SetText()/SetTextAsync() call, so the render this function just did is
+    // already up to date - there is nothing left for Update() to redo.
+    _ellipsisStyleChanged = false;
 }
 
 QueueTask<void> LabelView::UpdateTileBufferAsync(TaskQueueBase* taskQueue)

--- a/arm9/source/romBrowser/DisplayMode/BannerListFileRecyclerAdapter.cpp
+++ b/arm9/source/romBrowser/DisplayMode/BannerListFileRecyclerAdapter.cpp
@@ -28,6 +28,11 @@ void BannerListFileRecyclerAdapter::BindView(SharedPtr<View> view, int index) co
 TaskResult<void> BannerListFileRecyclerAdapter::BindView(SharedPtr<View> view, int index,
     const InternalFileInfo* internalFileInfo, const vu8& cancelRequested) const
 {
+    if (cancelRequested)
+    {
+        return TaskResult<void>::Canceled();
+    }
+
     auto listItemView = static_cast<BannerListItemView*>(view.GetPointer());
     listItemView->GetViewModel().SetIndex(index);
     const auto& fileInfo = _fileInfoManager->GetItem(index);

--- a/arm9/source/romBrowser/viewModels/IRomBrowserItemViewModel.h
+++ b/arm9/source/romBrowser/viewModels/IRomBrowserItemViewModel.h
@@ -12,6 +12,12 @@ public:
     virtual void SetQueueTask(QueueTask<void> queueTask) = 0;
     virtual void CancelQueueTask() = 0;
     virtual void DisposeQueueTaskWhenComplete() = 0;
+    /// @brief Whether the background task that loads this row's title/icon is
+    ///        still running (or hasn't started yet). While true, that task's
+    ///        completion will still call SetGameTitle()/SetFileName() from the
+    ///        IO thread, so anything driven from the main thread must not
+    ///        touch the same labels at the same time.
+    virtual bool IsQueueTaskPending() const = 0;
 
 protected:
     IRomBrowserItemViewModel() = default;

--- a/arm9/source/romBrowser/viewModels/RomBrowserItemViewModel.h
+++ b/arm9/source/romBrowser/viewModels/RomBrowserItemViewModel.h
@@ -29,10 +29,15 @@ public:
 
     void DisposeQueueTaskWhenComplete() override
     {
-        if (_queueTask.GetTask().IsCompleted())
+        if (_queueTask.IsValid() && _queueTask.GetTask().IsCompleted())
         {
             _queueTask.Dispose();
         }
+    }
+
+    bool IsQueueTaskPending() const override
+    {
+        return _queueTask.IsValid() && !_queueTask.GetTask().IsCompleted();
     }
 
 private:

--- a/arm9/source/romBrowser/views/BannerListItemView.cpp
+++ b/arm9/source/romBrowser/views/BannerListItemView.cpp
@@ -21,6 +21,25 @@ void BannerListItemView::Update()
 {
     _viewModel->DisposeQueueTaskWhenComplete();
 
+    // While this row's background load task is still pending, its completion
+    // will call SetGameTitle()/SetFileName() - which render straight into
+    // _firstLine/_secondLine/_thirdLine's text buffers - from the IO thread.
+    // Marquee scrolling (below, via ViewContainer::Update() -> LabelView::
+    // Update()) re-renders those same buffers every frame from the *main*
+    // thread with no locking, so letting it run while the load is still in
+    // flight races the IO thread and produces blank/garbled or wrong text -
+    // most visibly on the focused row, since that's the one marquee applies
+    // to. Skip it for this frame; once the load task completes it'll pick up
+    // normally on the next one.
+    if (_viewModel->IsQueueTaskPending())
+    {
+        if (_icon)
+        {
+            _icon->Update();
+        }
+        return;
+    }
+
     if (IsFocused())
     {
         _firstLine->SetEllipsisStyle(LabelView::EllipsisStyle::Marquee);

--- a/arm9/source/settings/viewModels/ThemeListItemViewModel.h
+++ b/arm9/source/settings/viewModels/ThemeListItemViewModel.h
@@ -33,10 +33,15 @@ public:
 
     void DisposeQueueTaskWhenComplete() override
     {
-        if (_queueTask.GetTask().IsCompleted())
+        if (_queueTask.IsValid() && _queueTask.GetTask().IsCompleted())
         {
             _queueTask.Dispose();
         }
+    }
+
+    bool IsQueueTaskPending() const override
+    {
+        return _queueTask.IsValid() && !_queueTask.GetTask().IsCompleted();
     }
 
     const ThemeInfoManager::ExtraThemeInfo* GetExtraThemeInfo() const


### PR DESCRIPTION
A row's background load task calls `SetGameTitle()`/`SetFileName()` from the IO
thread, writing straight into the row's text buffers. When a row is recycled or
its view rebuilt while that task is still in flight, the task keeps writing into
buffers that no longer belong to it — so a title can land on the wrong row, or
overwrite one that is being drawn.

`TaskQueue::RequestCancel()` only sets a flag, so a task that has already
started on the IO thread continues until its next cancellation check.
Cancellation now waits for the task to actually reach `Canceled` or `Completed`
before returning, so the caller can safely treat whatever it was touching as
free.

`LabelView` also clears its pending-update flag when the text buffer is
rewritten, rather than later in `Update()`. `SetEllipsisStyle()` and `SetText()`
are issued back to back from the background path, and the intermediate state
was observable.

The view models gain `IsQueueTaskPending()` so a row can tell whether its own
load task is still outstanding.

## Testing

Tested on hardware (DS Lite) by scrolling the banner list fast enough to recycle
rows while their icons and titles were still loading. Builds with no new
warnings.